### PR TITLE
Refactor session generator preview layout

### DIFF
--- a/README_patch.md
+++ b/README_patch.md
@@ -1,0 +1,10 @@
+### Patch Notes
+
+- `ui/pages/session_page.py` now uses `two_columns` layout and the new
+  `render_preview` API.
+- Preview rendering lives in `ui/pages/session_preview_panel.py` and builds
+  `WorkoutBlock` components.
+- Exercise ID→meta mapping handled in
+  `controllers/session_controller.generate_session_preview`.
+- New helper `two_columns` in `ui/components/layout.py` creates the fixed-width
+  form column and scrollable preview column.

--- a/controllers/session_controller.py
+++ b/controllers/session_controller.py
@@ -1,0 +1,63 @@
+"""Controller utilities for session preview generation."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Tuple
+
+from repositories.exercices_repo import ExerciseRepository
+from services.session_generator import generate_collectif
+
+
+def build_session_preview_dto(
+    blocks: list[Any], exercises_by_id: Dict[str, Dict[str, Any]]
+) -> Dict[str, Any]:
+    """Map session blocks to a DTO consumable by the view."""
+    blocks_out: list[Dict[str, Any]] = []
+    for blk in blocks:
+        title = f"{blk.type} — {blk.duration_sec // 60}’" if blk.duration_sec else blk.type
+        block_dto = {
+            "title": title,
+            "format": blk.type,
+            "duration": f"{blk.duration_sec // 60}’" if blk.duration_sec else "",
+            "exercises": [],
+        }
+        for item in blk.items:
+            meta = exercises_by_id.get(item.exercise_id, {})
+            name = meta.get("name", f"Exercice #{item.exercise_id}")
+            muscle = meta.get("primary_muscle", "")
+            equip = " / ".join(meta.get("equipment", []))
+            presc = item.prescription or {}
+            reps = None
+            if "reps" in presc:
+                reps = f"{presc['reps']} reps"
+            elif "work_sec" in presc:
+                reps = f"{presc['work_sec']}s"
+            exercise = {
+                "id": item.exercise_id,
+                "nom": name,
+                "reps": reps,
+                "repos_s": presc.get("rest_sec"),
+                "muscle": muscle,
+                "equip": equip,
+            }
+            block_dto["exercises"].append(exercise)
+        blocks_out.append(block_dto)
+    return {"blocks": blocks_out}
+
+
+def generate_session_preview(params: Dict[str, Any]) -> Tuple[Any, Dict[str, Any]]:
+    """Generate a session and its preview DTO."""
+    session = generate_collectif(params)
+    ids = [it.exercise_id for b in session.blocks for it in b.items]
+    repo = ExerciseRepository()
+    meta = repo.get_meta_by_ids(ids)
+    dto = build_session_preview_dto(session.blocks, meta)
+    dto["meta"] = {
+        "title": session.label,
+        "duration": f"{session.duration_sec // 60} min",
+    }
+    return session, dto
+
+
+__all__ = ["build_session_preview_dto", "generate_session_preview"]
+

--- a/repositories/exercices_repo.py
+++ b/repositories/exercices_repo.py
@@ -83,3 +83,29 @@ class ExerciseRepository:
                 "equipment": _split_csv(r["equipment"]),
             }
         return out
+
+    def get_meta_by_ids(self, ids: list[str]) -> dict[str, Dict[str, Any]]:
+        """Return basic metadata for each exercise id.
+
+        The mapping includes the name, primary muscle group and equipment
+        list. Missing IDs are simply omitted from the result.
+        """
+        if not ids:
+            return {}
+        unique_ids = list(dict.fromkeys(ids))
+        placeholders = ",".join(["?"] * len(unique_ids))
+        q = (
+            "SELECT exercise_id, name, primary_muscle, equipment "
+            f"FROM exercises WHERE exercise_id IN ({placeholders})"
+        )
+        with sqlite3.connect(self.db_path) as conn:
+            conn.row_factory = sqlite3.Row
+            rows = conn.execute(q, unique_ids).fetchall()
+        out: dict[str, Dict[str, Any]] = {}
+        for r in rows:
+            out[r["exercise_id"]] = {
+                "name": r["name"],
+                "primary_muscle": r["primary_muscle"],
+                "equipment": _split_csv(r["equipment"]),
+            }
+        return out

--- a/ui/components/layout.py
+++ b/ui/components/layout.py
@@ -1,0 +1,23 @@
+"""Reusable layout helpers."""
+
+import customtkinter as ctk
+
+
+def two_columns(parent, left_width: int = 360):
+    """Create a two-column grid within ``parent``.
+
+    The left column has a fixed ``left_width`` while the right column expands to
+    occupy remaining space. Both columns are returned as ``CTkScrollableFrame``
+    instances so their content can scroll independently.
+    """
+    parent.grid_rowconfigure(0, weight=1)
+    parent.grid_columnconfigure(0, weight=0, minsize=left_width)
+    parent.grid_columnconfigure(1, weight=1)
+
+    left = ctk.CTkScrollableFrame(parent, width=left_width, fg_color="#222")
+    right = ctk.CTkScrollableFrame(parent, fg_color="#171717")
+    return left, right
+
+
+__all__ = ["two_columns"]
+

--- a/ui/components/workout_block.py
+++ b/ui/components/workout_block.py
@@ -1,0 +1,82 @@
+"""Compact visual card representing a workout block."""
+
+import customtkinter as ctk
+
+
+FORMAT_COLORS = {
+    "EMOM": "#22D3EE",
+    "AMRAP": "#F59E0B",
+    "FOR_TIME": "#10B981",
+    "TABATA": "#A78BFA",
+    "SETSxREPS": "#94A3B8",
+}
+
+
+class WorkoutBlock(ctk.CTkFrame):
+    """Block card with a colored strip and compact exercise list."""
+
+    def __init__(self, parent, title: str, fmt: str, duration: str = ""):
+        super().__init__(parent, fg_color="#1d1d1d", corner_radius=8)
+        color = FORMAT_COLORS.get(fmt.upper(), "#94A3B8")
+
+        strip = ctk.CTkFrame(self, fg_color=color, width=4, corner_radius=0)
+        strip.pack(side="left", fill="y")
+
+        body = ctk.CTkFrame(self, fg_color="transparent")
+        body.pack(side="left", fill="both", expand=True, padx=6, pady=6)
+
+        header = ctk.CTkFrame(body, fg_color="transparent")
+        header.pack(fill="x")
+        ctk.CTkLabel(header, text=title, font=("", 13, "bold")).pack(side="left")
+        if duration:
+            ctk.CTkLabel(
+                header, text=duration, text_color="#9ca3af", font=("", 12)
+            ).pack(side="right")
+
+        self._ex_container = ctk.CTkFrame(body, fg_color="transparent")
+        self._ex_container.pack(fill="both", expand=True, pady=(4, 0))
+
+    # ------------------------------------------------------------------
+    def add_exercise(
+        self,
+        nom: str,
+        reps: str | None,
+        repos_s: int | None,
+        muscle: str,
+        equip: str,
+    ) -> None:
+        """Render a compact two-line exercise entry."""
+
+        wrapper = ctk.CTkFrame(self._ex_container, fg_color="transparent")
+        wrapper.pack(fill="x", pady=2)
+
+        top = ctk.CTkFrame(wrapper, fg_color="transparent")
+        top.pack(fill="x")
+        ctk.CTkLabel(top, text=nom, font=("", 12, "bold")).pack(side="left")
+
+        chips: list[str] = []
+        if reps:
+            chips.append(reps)
+        if repos_s is not None:
+            chips.append(f"repos {repos_s}s")
+        if chips:
+            chip = ctk.CTkLabel(
+                top,
+                text=" • ".join(chips),
+                fg_color="#2a2a2a",
+                corner_radius=6,
+                padx=4,
+                pady=1,
+                font=("", 11),
+                text_color="#d1d5db",
+            )
+            chip.pack(side="right")
+
+        bottom_txt = " · ".join(filter(None, [muscle, equip]))
+        ctk.CTkLabel(
+            wrapper, text=bottom_txt, font=("", 11), text_color="#9ca3af"
+        ).pack(anchor="w")
+
+
+__all__ = ["WorkoutBlock", "FORMAT_COLORS"]
+

--- a/ui/pages/session_page_components/session_form.py
+++ b/ui/pages/session_page_components/session_form.py
@@ -8,7 +8,7 @@ EQUIPMENTS = ["Haltères","Barre","Kettlebell","Poids du corps","Machine",
 FORMATS = ["EMOM","AMRAP","For Time","Tabata"]
 INTENSITIES = ["Low","Medium","High"]
 
-class SessionForm(ctk.CTkScrollableFrame):
+class SessionForm(ctk.CTkFrame):
     """
     A form for inputting session generation parameters.
     It encapsulates all the input fields and action buttons.

--- a/ui/pages/session_preview_panel.py
+++ b/ui/pages/session_preview_panel.py
@@ -1,0 +1,62 @@
+"""Preview rendering utilities for generated sessions."""
+
+from __future__ import annotations
+
+import customtkinter as ctk
+
+from ui.components.workout_block import WorkoutBlock
+
+
+def render_preview(container: ctk.CTkScrollableFrame, dto: dict) -> int:
+    """Render the session preview inside ``container``.
+
+    Returns the number of columns used so callers can avoid unnecessary
+    re-renders on resize events.
+    """
+    for w in container.winfo_children():
+        w.destroy()
+    if hasattr(container, "_parent_canvas"):
+        container._parent_canvas.yview_moveto(0.0)
+
+    width = container.winfo_toplevel().winfo_width()
+    cols = 2 if width >= 1200 else 1
+
+    meta = dto.get("meta", {})
+    if meta:
+        header = ctk.CTkFrame(container, fg_color="#1d2228", corner_radius=8)
+        header.pack(fill="x", padx=12, pady=(12, 6))
+        ctk.CTkLabel(
+            header, text=meta.get("title", ""), font=("", 13, "bold")
+        ).pack(side="left", padx=12, pady=8)
+        ctk.CTkLabel(
+            header,
+            text=meta.get("duration", ""),
+            text_color="#9ca3af",
+            font=("", 12),
+        ).pack(side="left", padx=12, pady=8)
+
+    grid = ctk.CTkFrame(container, fg_color="transparent")
+    grid.pack(fill="both", expand=True, padx=6, pady=6)
+    for c in range(cols):
+        grid.grid_columnconfigure(c, weight=1, uniform="blocks")
+
+    for i, block in enumerate(dto.get("blocks", [])):
+        wb = WorkoutBlock(
+            grid, block["title"], block.get("format", ""), block.get("duration", "")
+        )
+        r, c = divmod(i, cols)
+        wb.grid(row=r, column=c, sticky="nsew", padx=8, pady=8)
+        for ex in block.get("exercises", []):
+            wb.add_exercise(
+                ex.get("nom", ""),
+                ex.get("reps"),
+                ex.get("repos_s"),
+                ex.get("muscle", ""),
+                ex.get("equip", ""),
+            )
+
+    return cols
+
+
+__all__ = ["render_preview"]
+


### PR DESCRIPTION
## Summary
- introduce layout.two_columns helper and WorkoutBlock component
- generate preview DTO in session_controller and map exercise metadata
- refactor session page to responsive two-column design with dynamic preview rendering

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_689debb5d71c832abc9cb7c37a08557e