### PR TITLE
Refactor database schema for new coaching platform

### DIFF
--- a/db/schema.sql
+++ b/db/schema.sql
@@ -1,49 +1,44 @@
-CREATE TABLE IF NOT EXISTS exercises (
-  exercise_id TEXT PRIMARY KEY,
-  name TEXT NOT NULL,
-  primary_muscle TEXT,
-  secondary_muscles TEXT,
-  movement_pattern TEXT,
-  equipment TEXT,
-  unilateral INTEGER,
-  plane TEXT,
-  category TEXT,
-  level TEXT,
-  default_rep_range TEXT,
-  default_sets INTEGER,
-  default_rest_sec INTEGER,
-  avg_rep_time_sec REAL,
-  cues TEXT,
-  contraindications TEXT,
-  tags TEXT,
-  variants_of TEXT,
-  image_path TEXT
-);
-CREATE TABLE IF NOT EXISTS sessions (
-  session_id TEXT PRIMARY KEY,
-  mode TEXT NOT NULL,             -- COLLECTIF / INDIVIDUEL
-  label TEXT,
-  duration_sec INTEGER,
-  created_at TEXT DEFAULT CURRENT_TIMESTAMP
+DROP TABLE IF EXISTS resultats_exercices;
+DROP TABLE IF EXISTS seances;
+DROP TABLE IF EXISTS clients;
+DROP TABLE IF EXISTS exercices;
+
+CREATE TABLE exercices (
+    id INTEGER PRIMARY KEY,
+    nom TEXT NOT NULL UNIQUE,
+    groupe_musculaire_principal TEXT NOT NULL,
+    equipement TEXT,
+    type_effort TEXT NOT NULL,
+    coefficient_volume REAL DEFAULT 1.0,
+    est_chargeable BOOLEAN NOT NULL
 );
 
-CREATE TABLE IF NOT EXISTS session_blocks (
-  block_id TEXT PRIMARY KEY,
-  session_id TEXT NOT NULL REFERENCES sessions(session_id) ON DELETE CASCADE,
-  type TEXT,
-  duration_sec INTEGER,
-  rounds INTEGER,
-  work_sec INTEGER,
-  rest_sec INTEGER,
-  title TEXT,
-  locked INTEGER DEFAULT 0
+CREATE TABLE clients (
+    id INTEGER PRIMARY KEY,
+    nom TEXT NOT NULL,
+    prenom TEXT NOT NULL,
+    email TEXT UNIQUE,
+    date_naissance DATE
 );
 
-CREATE TABLE IF NOT EXISTS session_items (
-  item_id INTEGER PRIMARY KEY AUTOINCREMENT,
-  block_id TEXT NOT NULL REFERENCES session_blocks(block_id) ON DELETE CASCADE,
-  exercise_id TEXT,
-  prescription TEXT,  -- JSON (clé=valeur)
-  notes TEXT
+CREATE TABLE seances (
+    id INTEGER PRIMARY KEY,
+    client_id INTEGER,
+    type_seance TEXT NOT NULL,
+    titre TEXT NOT NULL,
+    date_creation DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY(client_id) REFERENCES clients(id)
+);
+
+CREATE TABLE resultats_exercices (
+    id INTEGER PRIMARY KEY,
+    seance_id INTEGER NOT NULL,
+    exercice_id INTEGER NOT NULL,
+    series_effectuees INTEGER,
+    reps_effectuees INTEGER,
+    charge_utilisee REAL,
+    feedback_client TEXT,
+    FOREIGN KEY(seance_id) REFERENCES seances(id),
+    FOREIGN KEY(exercice_id) REFERENCES exercices(id)
 );
 

--- a/db/seed.py
+++ b/db/seed.py
@@ -1,39 +1,95 @@
-import csv, sqlite3, os
+import sqlite3
 
 DB_PATH = "coach.db"
-CSV_PATH = "data/exercices_master.csv"
 SCHEMA_PATH = "db/schema.sql"
 
-def ensure_db():
+
+def reset_db():
     with sqlite3.connect(DB_PATH) as conn, open(SCHEMA_PATH, "r", encoding="utf-8") as f:
         conn.executescript(f.read())
 
-def import_csv():
-    if not os.path.exists(CSV_PATH):
-        print(f"[seed] CSV not found: {CSV_PATH} — skip")
-        return
-    with sqlite3.connect(DB_PATH) as conn, open(CSV_PATH, newline="", encoding="utf-8") as f:
-        reader = csv.DictReader(f)
-        rows = list(reader)
-        conn.execute("DELETE FROM exercises")
-        for r in rows:
-            conn.execute("""
-            INSERT OR REPLACE INTO exercises (
-              exercise_id, name, primary_muscle, secondary_muscles, movement_pattern, equipment,
-              unilateral, plane, category, level, default_rep_range, default_sets, default_rest_sec,
-              avg_rep_time_sec, cues, contraindications, tags, variants_of, image_path
-            ) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
-            """, (
-              r["exercise_id"], r["name"], r["primary_muscle"], r["secondary_muscles"], r["movement_pattern"],
-              r["equipment"], 1 if r["unilateral"].strip().lower() in ("1","true","yes") else 0,
-              r["plane"], r["category"], r["level"], r["default_rep_range"],
-              int(r["default_sets"] or 0), int(r["default_rest_sec"] or 0),
-              float(r["avg_rep_time_sec"] or 2.5), r["cues"], r["contraindications"], r["tags"],
-              r.get("variants_of") or None, r.get("image_path") or None
-            ))
+
+def seed():
+    with sqlite3.connect(DB_PATH) as conn:
+        conn.executescript(
+            """
+            DELETE FROM resultats_exercices;
+            DELETE FROM seances;
+            DELETE FROM clients;
+            DELETE FROM exercices;
+            """
+        )
+
+        exercices = [
+            ("Squat", "Jambes", "Barre", "Force", 1.0, 1),
+            ("Fente avant", "Jambes", "Haltères", "Hypertrophie", 0.8, 1),
+            ("Développé couché", "Pectoraux", "Barre", "Force", 1.0, 1),
+            ("Tractions", "Dos", "Barre fixe", "Hypertrophie", 1.0, 1),
+            ("Rowing haltère", "Dos", "Haltère", "Hypertrophie", 0.8, 1),
+            ("Planche", "Abdominaux", "Tapis", "Stabilité", 0.5, 0),
+            ("Burpees", "Full body", "Poids du corps", "Cardio", 1.2, 0),
+            ("Saut en hauteur", "Jambes", "Poids du corps", "Pliométrie", 1.0, 0),
+            ("Course à pied", "Jambes", "Tapis", "Endurance", 1.0, 0),
+            ("Développé militaire", "Épaules", "Barre", "Force", 0.9, 1),
+            ("Élévation latérale", "Épaules", "Haltères", "Hypertrophie", 0.3, 1),
+            ("Crunch", "Abdominaux", "Poids du corps", "Hypertrophie", 0.4, 0),
+        ]
+        conn.executemany(
+            """
+            INSERT INTO exercices (
+                nom, groupe_musculaire_principal, equipement,
+                type_effort, coefficient_volume, est_chargeable
+            ) VALUES (?,?,?,?,?,?)
+            """,
+            exercices,
+        )
+
+        clients = [
+            ("Doe", "John", "john@example.com", "1990-01-01"),
+            ("Smith", "Anna", "anna@example.com", "1985-05-12"),
+            ("Martin", "Lucas", "lucas@example.com", "1995-07-23"),
+            ("Durand", "Sophie", "sophie@example.com", "1992-11-05"),
+        ]
+        conn.executemany(
+            "INSERT INTO clients (nom, prenom, email, date_naissance) VALUES (?,?,?,?)",
+            clients,
+        )
+
+        seances = [
+            (1, "Individuel", "Séance jambes"),
+            (2, "Individuel", "Séance haut du corps"),
+            (None, "Collectif", "Cours HIIT"),
+            (None, "Collectif", "Yoga matinal"),
+        ]
+        conn.executemany(
+            "INSERT INTO seances (client_id, type_seance, titre) VALUES (?,?,?)",
+            seances,
+        )
+
+        def get_exercice_id(nom):
+            cur = conn.execute("SELECT id FROM exercices WHERE nom = ?", (nom,))
+            return cur.fetchone()[0]
+
+        resultats = [
+            (1, get_exercice_id("Squat"), 4, 8, 100, "Difficile"),
+            (1, get_exercice_id("Fente avant"), 3, 10, 40, "Brûlant"),
+            (2, get_exercice_id("Développé couché"), 4, 8, 80, "Facile"),
+            (2, get_exercice_id("Tractions"), 3, 6, 0, "Difficile"),
+        ]
+        conn.executemany(
+            """
+            INSERT INTO resultats_exercices (
+                seance_id, exercice_id, series_effectuees,
+                reps_effectuees, charge_utilisee, feedback_client
+            ) VALUES (?,?,?,?,?,?)
+            """,
+            resultats,
+        )
+
         conn.commit()
-    print(f"[seed] Imported {len(rows)} exercises.")
+
 
 if __name__ == "__main__":
-    ensure_db()
-    import_csv()
+    reset_db()
+    seed()
+


### PR DESCRIPTION
## Summary
- overhaul schema to support exercices, clients, seances, and resultats_exercices tables
- seed database with sample exercises, clients, sessions and results for testing

## Testing
- `python db/seed.py`


------
https://chatgpt.com/codex/tasks/task_e_689e27e055dc832ab0a864e40b4fa2fa