### PR TITLE
Add basic client and session data models and repository

### DIFF
--- a/models/__init__.py
+++ b/models/__init__.py
@@ -1,0 +1,3 @@
+from .client import Client
+from .seance import Seance
+from .resultat_exercice import ResultatExercice

--- a/models/client.py
+++ b/models/client.py
@@ -1,0 +1,11 @@
+from dataclasses import dataclass
+from typing import Optional
+
+
+@dataclass
+class Client:
+    id: int
+    nom: str
+    prenom: str
+    email: Optional[str] = None
+    date_naissance: Optional[str] = None

--- a/models/resultat_exercice.py
+++ b/models/resultat_exercice.py
@@ -1,0 +1,13 @@
+from dataclasses import dataclass
+from typing import Optional
+
+
+@dataclass
+class ResultatExercice:
+    id: int
+    seance_id: int
+    exercice_id: int
+    series_effectuees: Optional[int] = None
+    reps_effectuees: Optional[int] = None
+    charge_utilisee: Optional[float] = None
+    feedback_client: Optional[str] = None

--- a/models/seance.py
+++ b/models/seance.py
@@ -1,0 +1,14 @@
+from dataclasses import dataclass, field
+from typing import List, Optional
+
+from .resultat_exercice import ResultatExercice
+
+
+@dataclass
+class Seance:
+    id: int
+    client_id: Optional[int]
+    type_seance: str
+    titre: str
+    date_creation: str
+    resultats: List[ResultatExercice] = field(default_factory=list)

--- a/repositories/client_repo.py
+++ b/repositories/client_repo.py
@@ -1,0 +1,28 @@
+import sqlite3
+from typing import List
+
+from models.client import Client
+
+DB_PATH = "coach.db"
+
+
+class ClientRepository:
+    def __init__(self, db_path: str = DB_PATH):
+        self.db_path = db_path
+
+    def list_all(self) -> List[Client]:
+        with sqlite3.connect(self.db_path) as conn:
+            conn.row_factory = sqlite3.Row
+            rows = conn.execute(
+                "SELECT * FROM clients ORDER BY nom, prenom"
+            ).fetchall()
+        return [
+            Client(
+                id=row["id"],
+                nom=row["nom"],
+                prenom=row["prenom"],
+                email=row["email"],
+                date_naissance=row["date_naissance"],
+            )
+            for row in rows
+        ]


### PR DESCRIPTION
## Summary
- add Client, Seance, and ResultatExercice dataclasses
- expose new models in models package
- implement ClientRepository.list_all to load clients from SQLite

## Testing
- `python -m py_compile models/client.py models/resultat_exercice.py models/seance.py repositories/client_repo.py models/__init__.py`


------
https://chatgpt.com/codex/tasks/task_e_689e3558ccc0832a874cee3b8b98cf08