### PR TITLE
Connect individual session generator to controller

### DIFF
--- a/controllers/session_controller.py
+++ b/controllers/session_controller.py
@@ -45,18 +45,34 @@ def build_session_preview_dto(
     return {"blocks": blocks_out}
 
 
-def generate_session_preview(params: Dict[str, Any]) -> Tuple[Any, Dict[str, Any]]:
+def generate_session_preview(
+    params: Dict[str, Any], mode: str = "collectif"
+) -> Tuple[Any, Dict[str, Any]]:
     """Generate a session and its preview DTO."""
-    session = generate_collectif(params)
-    ids = [it.exercise_id for b in session.blocks for it in b.items]
-    repo = ExerciseRepository()
-    meta = repo.get_meta_by_ids(ids)
-    dto = build_session_preview_dto(session.blocks, meta)
-    dto["meta"] = {
-        "title": session.label,
-        "duration": f"{session.duration_sec // 60} min",
-    }
-    return session, dto
+    if mode == "collectif":
+        session = generate_collectif(params)
+        ids = [it.exercise_id for b in session.blocks for it in b.items]
+        repo = ExerciseRepository()
+        meta = repo.get_meta_by_ids(ids)
+        dto = build_session_preview_dto(session.blocks, meta)
+        dto["meta"] = {
+            "title": session.label,
+            "duration": f"{session.duration_sec // 60} min",
+        }
+        return session, dto
+    elif mode == "individuel":
+        session = {"client": params.get("client"), "goal": params.get("goal")}
+        dto = {
+            "meta": {
+                "title": f"Séance pour {session['client']}",
+                "goal": session["goal"],
+                "duration": "45 min",
+            },
+            "blocks": [],
+        }
+        return session, dto
+    else:
+        raise ValueError(f"Unknown mode: {mode}")
 
 
 __all__ = ["build_session_preview_dto", "generate_session_preview"]

--- a/ui/pages/session_page.py
+++ b/ui/pages/session_page.py
@@ -83,7 +83,7 @@ class SessionPage(ctk.CTkFrame):
     def on_generate_collectif(self):
         """Génère une séance collective et met à jour l'aperçu."""
         params = self.form_collectif.get_params()
-        self._last_session, dto = generate_session_preview(params)
+        self._last_session, dto = generate_session_preview(params, mode="collectif")
         self._last_dto = dto
         self._current_cols = render_preview(self.right_col, dto)
 
@@ -93,13 +93,7 @@ class SessionPage(ctk.CTkFrame):
     def on_generate_individuel(self):
         """Génère un aperçu de séance individuelle."""
         params = self.form_individuel.get_params()
-        dto = {
-            "meta": {
-                "title": f"Aperçu pour {params['client']} - Objectif : {params['goal']}",
-            },
-            "blocks": [],
-        }
-        self._last_session = None
+        self._last_session, dto = generate_session_preview(params, mode="individuel")
         self._last_dto = dto
         self._current_cols = render_preview(self.right_col, dto)
 

--- a/ui/pages/session_page_components/form_individuel.py
+++ b/ui/pages/session_page_components/form_individuel.py
@@ -1,6 +1,6 @@
 import customtkinter as ctk
+from repositories.client_repo import ClientRepository
 
-CLIENTS = ["Client A", "Client B", "Client C"]
 OBJECTIFS = ["Volume", "Force", "Endurance", "Technique"]
 
 
@@ -25,8 +25,11 @@ class FormIndividuel(ctk.CTkFrame):
         ctk.CTkLabel(row1, text="Sélectionner un client").grid(
             row=0, column=0, sticky="w", padx=(0, 8)
         )
-        self.client_var = ctk.StringVar(value=CLIENTS[0])
-        ctk.CTkOptionMenu(row1, variable=self.client_var, values=CLIENTS).grid(
+        repo = ClientRepository()
+        clients = repo.list_all()
+        client_names = [f"{c.prenom} {c.nom}" for c in clients]
+        self.client_var = ctk.StringVar(value=client_names[0] if client_names else "")
+        ctk.CTkOptionMenu(row1, variable=self.client_var, values=client_names).grid(
             row=0, column=1, sticky="ew", padx=(0, 12)
         )
 


### PR DESCRIPTION
## Summary
- Dynamically load client names in individual session form from the database
- Extend session preview controller to handle collective and individual modes
- Route individual and collective session generation through unified controller

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689e3b3756d4832a9c9f093ee70f5618