### PR TITLE
Add client detail page with navigation

### DIFF
--- a/app.py
+++ b/app.py
@@ -11,6 +11,7 @@ from ui.pages.database_page import DatabasePage
 from ui.pages.progress_page import ProgressPage
 from ui.pages.pdf_page import PdfPage
 from ui.pages.clients_page import ClientsPage
+from ui.pages.client_detail_page import ClientDetailPage
 from ui.pages.messaging_page import MessagingPage
 from ui.pages.billing_page import BillingPage
 from ui.layout.header import Header
@@ -41,6 +42,8 @@ class CoachApp(ctk.CTk):
         self.main_frame.pack(side="left", fill="both", expand=True)
 
         self.current_page = None
+        self.clients_page = None
+        self.client_detail_page = None
         self.switch_page("dashboard")  # Page par défaut
 
     def switch_page(self, page_name):
@@ -69,7 +72,8 @@ class CoachApp(ctk.CTk):
             case "pdf":
                 self.current_page = PdfPage(self.main_frame)
             case "clients":
-                self.current_page = ClientsPage(self.main_frame)
+                self.clients_page = ClientsPage(self.main_frame)
+                self.current_page = self.clients_page
             case "messaging":
                 self.current_page = MessagingPage(self.main_frame)
             case "billing":
@@ -78,6 +82,24 @@ class CoachApp(ctk.CTk):
                 self.current_page = DashboardPage(self.main_frame)
 
         self.current_page.pack(fill="both", expand=True)
+
+    def show_client_detail(self, client_id: int) -> None:
+        """Affiche la page de détail d'un client."""
+        if self.clients_page:
+            self.clients_page.pack_forget()
+        self.client_detail_page = ClientDetailPage(self.main_frame, client_id)
+        self.client_detail_page.pack(fill="both", expand=True)
+        self.current_page = self.client_detail_page
+
+    def show_clients_page(self) -> None:
+        """Revient à la page de liste des clients."""
+        if self.client_detail_page:
+            self.client_detail_page.pack_forget()
+            self.client_detail_page.destroy()
+            self.client_detail_page = None
+        if self.clients_page:
+            self.clients_page.pack(fill="both", expand=True)
+            self.current_page = self.clients_page
 
 def launch_app():
     ctk.set_appearance_mode("dark")

--- a/repositories/client_repo.py
+++ b/repositories/client_repo.py
@@ -1,5 +1,5 @@
 import sqlite3
-from typing import List
+from typing import List, Optional
 
 from models.client import Client
 
@@ -44,3 +44,21 @@ class ClientRepository:
                 (client.nom, client.prenom, client.email, client.date_naissance, client.id),
             )
             conn.commit()
+
+    def find_by_id(self, client_id: int) -> Optional[Client]:
+        """Récupère un client par son identifiant."""
+        with sqlite3.connect(self.db_path) as conn:
+            conn.row_factory = sqlite3.Row
+            row = conn.execute(
+                "SELECT * FROM clients WHERE id = ?",
+                (client_id,),
+            ).fetchone()
+        if row is None:
+            return None
+        return Client(
+            id=row["id"],
+            nom=row["nom"],
+            prenom=row["prenom"],
+            email=row["email"],
+            date_naissance=row["date_naissance"],
+        )

--- a/ui/pages/client_detail_page.py
+++ b/ui/pages/client_detail_page.py
@@ -1,0 +1,53 @@
+import customtkinter as ctk
+
+from repositories.client_repo import ClientRepository
+from ui.theme.fonts import get_title_font, get_text_font
+from ui.theme.colors import DARK_BG, TEXT
+
+
+class ClientDetailPage(ctk.CTkFrame):
+    """Page affichant les détails d'un client."""
+
+    def __init__(self, master, client_id: int):
+        super().__init__(master, fg_color=DARK_BG)
+        self.client_id = client_id
+        repo = ClientRepository()
+        client = repo.find_by_id(client_id)
+
+        ctk.CTkButton(
+            self,
+            text="< Retour",
+            command=self.master.master.show_clients_page,
+            width=100,
+        ).pack(anchor="w", padx=20, pady=(20, 10))
+
+        if client:
+            title = f"{client.prenom} {client.nom}"
+            email = client.email or "Non renseigné"
+            birth = client.date_naissance or "Non renseigné"
+        else:
+            title = "Client introuvable"
+            email = "Non renseigné"
+            birth = "Non renseigné"
+
+        ctk.CTkLabel(
+            self,
+            text=title,
+            font=get_title_font(),
+            text_color=TEXT,
+        ).pack(anchor="w", padx=20, pady=(0, 20))
+
+        ctk.CTkLabel(
+            self,
+            text=f"Email : {email}",
+            font=get_text_font(),
+            text_color=TEXT,
+        ).pack(anchor="w", padx=20, pady=(0, 5))
+
+        ctk.CTkLabel(
+            self,
+            text=f"Date de naissance : {birth}",
+            font=get_text_font(),
+            text_color=TEXT,
+        ).pack(anchor="w", padx=20)
+

--- a/ui/pages/clients_page.py
+++ b/ui/pages/clients_page.py
@@ -51,8 +51,11 @@ class ClientsPage(ctk.CTkFrame):
         info.pack(side="left", padx=10, pady=10)
 
         full_name = f"{client.prenom} {client.nom}"
-        ctk.CTkLabel(info, text=full_name, font=get_text_font(), text_color=TEXT).pack(anchor="w")
-        ctk.CTkLabel(info, text=client.email or "", font=get_small_font(), text_color=TEXT_SECONDARY).pack(anchor="w")
+        name_label = ctk.CTkLabel(info, text=full_name, font=get_text_font(), text_color=TEXT)
+        name_label.pack(anchor="w")
+        email = client.email or "Non renseigné"
+        email_label = ctk.CTkLabel(info, text=email, font=get_small_font(), text_color=TEXT_SECONDARY)
+        email_label.pack(anchor="w")
 
         ctk.CTkButton(
             card,
@@ -60,6 +63,14 @@ class ClientsPage(ctk.CTkFrame):
             command=lambda c=client: self._open_edit_modal(c),
             width=100,
         ).pack(side="right", padx=10, pady=10)
+
+        # Rendre la carte cliquable
+        widgets_to_bind = [card, info, name_label, email_label]
+        for widget in widgets_to_bind:
+            widget.bind("<Button-1>", lambda e, cid=client.id: self.on_client_selected(cid))
+
+    def on_client_selected(self, client_id: int) -> None:
+        self.master.master.show_client_detail(client_id)
 
     # -- Modal handlers ---------------------------------------------------
     def _open_add_modal(self) -> None:


### PR DESCRIPTION
## Summary
- make client cards clickable and navigate to detail page
- add ClientDetailPage to show basic info and back button
- support retrieving clients by id in repository

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689e542d4464832aae7ed43bf6e81659