### PR TITLE
feat: add workout logging

### DIFF
--- a/models/seance.py
+++ b/models/seance.py
@@ -6,6 +6,8 @@ from .resultat_exercice import ResultatExercice
 
 @dataclass
 class Seance:
+    """Représente une séance d'entraînement ainsi que ses résultats."""
+
     id: int
     client_id: Optional[int]
     type_seance: str

--- a/repositories/seance_repo.py
+++ b/repositories/seance_repo.py
@@ -1,0 +1,82 @@
+import sqlite3
+from typing import List
+
+from models.seance import Seance
+from models.resultat_exercice import ResultatExercice
+
+DB_PATH = "coach.db"
+
+
+class SeanceRepository:
+    def __init__(self, db_path: str = DB_PATH):
+        self.db_path = db_path
+
+    def get_by_client_id(self, client_id: int) -> List[Seance]:
+        """Return all sessions for a client ordered from most recent to oldest."""
+        with sqlite3.connect(self.db_path) as conn:
+            conn.row_factory = sqlite3.Row
+            seance_rows = conn.execute(
+                "SELECT * FROM seances WHERE client_id = ? ORDER BY date_creation DESC",
+                (client_id,),
+            ).fetchall()
+            seances: List[Seance] = []
+            for s in seance_rows:
+                res_rows = conn.execute(
+                    "SELECT * FROM resultats_exercices WHERE seance_id = ?",
+                    (s["id"],),
+                ).fetchall()
+                resultats = [
+                    ResultatExercice(
+                        id=r["id"],
+                        seance_id=r["seance_id"],
+                        exercice_id=r["exercice_id"],
+                        series_effectuees=r["series_effectuees"],
+                        reps_effectuees=r["reps_effectuees"],
+                        charge_utilisee=r["charge_utilisee"],
+                        feedback_client=r["feedback_client"],
+                    )
+                    for r in res_rows
+                ]
+                seances.append(
+                    Seance(
+                        id=s["id"],
+                        client_id=s["client_id"],
+                        type_seance=s["type_seance"],
+                        titre=s["titre"],
+                        date_creation=s["date_creation"],
+                        resultats=resultats,
+                    )
+                )
+            return seances
+
+    def add_seance(self, seance: Seance, resultats: List[ResultatExercice]) -> None:
+        """Insert a new session and all its exercise results in a single transaction."""
+        with sqlite3.connect(self.db_path) as conn:
+            cur = conn.cursor()
+            cur.execute(
+                "INSERT INTO seances (client_id, type_seance, titre, date_creation) VALUES (?, ?, ?, ?)",
+                (
+                    seance.client_id,
+                    seance.type_seance,
+                    seance.titre,
+                    seance.date_creation,
+                ),
+            )
+            seance_id = cur.lastrowid
+            for r in resultats:
+                cur.execute(
+                    """
+                    INSERT INTO resultats_exercices (
+                        seance_id, exercice_id, series_effectuees, reps_effectuees, charge_utilisee, feedback_client
+                    ) VALUES (?, ?, ?, ?, ?, ?)
+                    """,
+                    (
+                        seance_id,
+                        r.exercice_id,
+                        r.series_effectuees,
+                        r.reps_effectuees,
+                        r.charge_utilisee,
+                        r.feedback_client,
+                    ),
+                )
+            conn.commit()

--- a/ui/modals/session_log_modal.py
+++ b/ui/modals/session_log_modal.py
@@ -1,0 +1,144 @@
+import customtkinter as ctk
+from typing import Callable, List, Dict
+
+from models.seance import Seance
+from models.resultat_exercice import ResultatExercice
+from repositories.seance_repo import SeanceRepository
+from repositories.exercices_repo import ExerciseRepository
+from ui.theme.colors import DARK_BG
+
+
+class SessionLogModal(ctk.CTkToplevel):
+    def __init__(self, parent, client_id: int, on_saved: Callable[[], None] | None = None):
+        super().__init__(parent)
+        self.client_id = client_id
+        self.on_saved = on_saved
+        self.seance_repo = SeanceRepository()
+        self.exercise_repo = ExerciseRepository()
+
+        self.title("Enregistrer une séance")
+        self.geometry("500x600")
+        self.configure(fg_color=DARK_BG)
+        self.resizable(False, False)
+
+        self.title_var = ctk.StringVar()
+        self.date_var = ctk.StringVar()
+
+        self._build_form()
+        self.exercise_entries: List[Dict] = []
+
+    def _build_form(self):
+        general = ctk.CTkFrame(self, fg_color="transparent")
+        general.pack(fill="x", padx=20, pady=(20, 10))
+
+        ctk.CTkLabel(general, text="Titre de la séance").pack(anchor="w")
+        ctk.CTkEntry(general, textvariable=self.title_var).pack(fill="x", pady=5)
+
+        ctk.CTkLabel(general, text="Date (AAAA-MM-JJ)").pack(anchor="w")
+        ctk.CTkEntry(general, textvariable=self.date_var).pack(fill="x", pady=5)
+
+        ex_container = ctk.CTkFrame(self, fg_color="transparent")
+        ex_container.pack(fill="both", expand=True, padx=20, pady=10)
+
+        add_frame = ctk.CTkFrame(ex_container, fg_color="transparent")
+        add_frame.pack(fill="x")
+
+        exercices = self.exercise_repo.list_all_exercices()
+        self.ex_map = {e.nom: e.id for e in exercices}
+        values = list(self.ex_map.keys()) if self.ex_map else [""]
+        self.option_var = ctk.StringVar(value=values[0] if values else "")
+        ctk.CTkOptionMenu(add_frame, variable=self.option_var, values=values).pack(
+            side="left", padx=(0, 10)
+        )
+        ctk.CTkButton(add_frame, text="Ajouter un exercice", command=self._add_exercise).pack(
+            side="left"
+        )
+
+        self.ex_scroll = ctk.CTkScrollableFrame(ex_container, fg_color="transparent")
+        self.ex_scroll.pack(fill="both", expand=True, pady=(10, 0))
+
+        action = ctk.CTkFrame(self, fg_color="transparent")
+        action.pack(pady=10)
+        ctk.CTkButton(action, text="Enregistrer la séance", command=self._save).pack(
+            side="left", padx=5
+        )
+        ctk.CTkButton(action, text="Annuler", command=self.destroy).pack(side="left", padx=5)
+
+    def _add_exercise(self):
+        name = self.option_var.get()
+        if not name:
+            return
+        ex_id = self.ex_map[name]
+        frame = ctk.CTkFrame(self.ex_scroll)
+        frame.pack(fill="x", pady=5, padx=5)
+
+        ctk.CTkLabel(frame, text=name, width=150).grid(row=0, column=0, padx=5)
+        series_var = ctk.StringVar()
+        reps_var = ctk.StringVar()
+        charge_var = ctk.StringVar()
+        ctk.CTkEntry(frame, width=40, textvariable=series_var, placeholder_text="Séries").grid(
+            row=0, column=1, padx=5
+        )
+        ctk.CTkEntry(frame, width=40, textvariable=reps_var, placeholder_text="Reps").grid(
+            row=0, column=2, padx=5
+        )
+        ctk.CTkEntry(frame, width=60, textvariable=charge_var, placeholder_text="Charge").grid(
+            row=0, column=3, padx=5
+        )
+        ctk.CTkButton(
+            frame, text="X", width=20, command=lambda: self._remove_exercise(frame)
+        ).grid(row=0, column=4, padx=5)
+
+        self.exercise_entries.append(
+            {
+                "id": ex_id,
+                "series": series_var,
+                "reps": reps_var,
+                "charge": charge_var,
+                "frame": frame,
+            }
+        )
+
+    def _remove_exercise(self, frame):
+        for entry in list(self.exercise_entries):
+            if entry["frame"] is frame:
+                entry["frame"].destroy()
+                self.exercise_entries.remove(entry)
+                break
+
+    def _save(self):
+        seance = Seance(
+            id=0,
+            client_id=self.client_id,
+            type_seance="manuel",
+            titre=self.title_var.get(),
+            date_creation=self.date_var.get(),
+        )
+        resultats: List[ResultatExercice] = []
+        for e in self.exercise_entries:
+            try:
+                series = int(e["series"].get()) if e["series"].get() else None
+            except ValueError:
+                series = None
+            try:
+                reps = int(e["reps"].get()) if e["reps"].get() else None
+            except ValueError:
+                reps = None
+            try:
+                charge = float(e["charge"].get()) if e["charge"].get() else None
+            except ValueError:
+                charge = None
+            resultats.append(
+                ResultatExercice(
+                    id=0,
+                    seance_id=0,
+                    exercice_id=e["id"],
+                    series_effectuees=series,
+                    reps_effectuees=reps,
+                    charge_utilisee=charge,
+                )
+            )
+        self.seance_repo.add_seance(seance, resultats)
+        if self.on_saved:
+            self.on_saved()
+        self.destroy()

--- a/ui/pages/client_detail_page.py
+++ b/ui/pages/client_detail_page.py
@@ -4,6 +4,7 @@ from repositories.client_repo import ClientRepository
 from ui.theme.fonts import get_title_font
 from ui.theme.colors import DARK_BG, TEXT
 from ui.pages.client_detail_page_components.anamnese_tab import AnamneseTab
+from ui.pages.client_detail_page_components.suivi_tab import SuiviTab
 
 
 class ClientDetailPage(ctk.CTkFrame):
@@ -39,4 +40,6 @@ class ClientDetailPage(ctk.CTkFrame):
         anam_tab = tabview.add("Anamnèse")
         if client:
             AnamneseTab(anam_tab, client).pack(fill="both", expand=True, padx=10, pady=10)
+        suivi_tab = tabview.add("Suivi & Séances")
+        SuiviTab(suivi_tab, self.client_id).pack(fill="both", expand=True, padx=10, pady=10)
 

--- a/ui/pages/client_detail_page_components/suivi_tab.py
+++ b/ui/pages/client_detail_page_components/suivi_tab.py
@@ -1,0 +1,35 @@
+import customtkinter as ctk
+
+from repositories.seance_repo import SeanceRepository
+from ui.modals.session_log_modal import SessionLogModal
+
+
+class SuiviTab(ctk.CTkFrame):
+    def __init__(self, master, client_id: int):
+        super().__init__(master, fg_color="transparent")
+        self.client_id = client_id
+        self.repo = SeanceRepository()
+
+        ctk.CTkButton(
+            self,
+            text="Enregistrer une nouvelle séance",
+            command=self._open_modal,
+        ).pack(anchor="e", padx=10, pady=10)
+
+        self.list_frame = ctk.CTkScrollableFrame(self, fg_color="transparent")
+        self.list_frame.pack(fill="both", expand=True, padx=10, pady=10)
+
+        self._load_seances()
+
+    def _load_seances(self):
+        for w in self.list_frame.winfo_children():
+            w.destroy()
+        seances = self.repo.get_by_client_id(self.client_id)
+        for s in seances:
+            item = ctk.CTkFrame(self.list_frame)
+            item.pack(fill="x", pady=5)
+            ctk.CTkLabel(item, text=s.titre).pack(side="left", padx=10)
+            ctk.CTkLabel(item, text=s.date_creation).pack(side="right", padx=10)
+
+    def _open_modal(self):
+        SessionLogModal(self, self.client_id, on_saved=self._load_seances)


### PR DESCRIPTION
## Summary
- add `SeanceRepository` for persisting sessions and exercise results
- add session logging modal and Suivi & Séances tab on client page
- document Seance model for storing exercise results

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_689f04df44f0832ab8fc7010afebc633