### PR TITLE
Add meal plan template management with nutrition editor

### DIFF
--- a/app.py
+++ b/app.py
@@ -65,6 +65,7 @@ class CoachApp(ctk.CTk):
                 self.current_page = CalendarPage(self.main_frame)
             case "nutrition":
                 self.current_page = NutritionPage(self.main_frame)
+                self.header.update_title("Nutrition")
             case "database":
                 self.current_page = DatabasePage(self.main_frame)
             case "progress":

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -78,3 +78,29 @@ CREATE TABLE portions (
     FOREIGN KEY(aliment_id) REFERENCES aliments(id)
 );
 
+CREATE TABLE plans_alimentaires (
+    id INTEGER PRIMARY KEY,
+    nom TEXT NOT NULL,
+    description TEXT,
+    tags TEXT
+);
+
+CREATE TABLE repas (
+    id INTEGER PRIMARY KEY,
+    plan_id INTEGER NOT NULL,
+    nom TEXT NOT NULL,
+    ordre INTEGER DEFAULT 0,
+    FOREIGN KEY(plan_id) REFERENCES plans_alimentaires(id)
+);
+
+CREATE TABLE repas_items (
+    id INTEGER PRIMARY KEY,
+    repas_id INTEGER NOT NULL,
+    aliment_id INTEGER NOT NULL,
+    portion_id INTEGER NOT NULL,
+    quantite REAL DEFAULT 1.0,
+    FOREIGN KEY(repas_id) REFERENCES repas(id),
+    FOREIGN KEY(aliment_id) REFERENCES aliments(id),
+    FOREIGN KEY(portion_id) REFERENCES portions(id)
+);
+

--- a/models/plan_alimentaire.py
+++ b/models/plan_alimentaire.py
@@ -1,0 +1,29 @@
+from dataclasses import dataclass, field
+from typing import List, Optional
+
+
+@dataclass
+class RepasItem:
+    id: int
+    repas_id: int
+    aliment_id: int
+    portion_id: int
+    quantite: float = 1.0
+
+
+@dataclass
+class Repas:
+    id: int
+    plan_id: int
+    nom: str
+    ordre: int = 0
+    items: List[RepasItem] = field(default_factory=list)
+
+
+@dataclass
+class PlanAlimentaire:
+    id: int
+    nom: str
+    description: Optional[str] = None
+    tags: Optional[str] = None
+    repas: List[Repas] = field(default_factory=list)

--- a/repositories/aliment_repo.py
+++ b/repositories/aliment_repo.py
@@ -2,6 +2,7 @@ import sqlite3
 from typing import List
 
 from models.aliment import Aliment
+from models.portion import Portion
 
 DB_PATH = "coach.db"
 
@@ -30,6 +31,23 @@ class AlimentRepository:
                 unite_base=row["unite_base"],
                 indice_healthy=row["indice_healthy"],
                 indice_commun=row["indice_commun"],
+            )
+            for row in rows
+        ]
+
+    def get_portions_for_aliment(self, aliment_id: int) -> List[Portion]:
+        with sqlite3.connect(self.db_path) as conn:
+            conn.row_factory = sqlite3.Row
+            rows = conn.execute(
+                "SELECT * FROM portions WHERE aliment_id = ? ORDER BY id",
+                (aliment_id,),
+            ).fetchall()
+        return [
+            Portion(
+                id=row["id"],
+                aliment_id=row["aliment_id"],
+                description=row["description"],
+                grammes_equivalents=row["grammes_equivalents"],
             )
             for row in rows
         ]

--- a/repositories/plan_alimentaire_repo.py
+++ b/repositories/plan_alimentaire_repo.py
@@ -1,0 +1,192 @@
+import sqlite3
+from typing import List
+
+from models.plan_alimentaire import PlanAlimentaire, Repas, RepasItem
+
+DB_PATH = "coach.db"
+
+
+class PlanAlimentaireRepository:
+    def __init__(self, db_path: str = DB_PATH):
+        self.db_path = db_path
+
+    # Plans
+    def list_plans(self) -> List[PlanAlimentaire]:
+        with sqlite3.connect(self.db_path) as conn:
+            conn.row_factory = sqlite3.Row
+            rows = conn.execute(
+                "SELECT * FROM plans_alimentaires ORDER BY nom"
+            ).fetchall()
+        return [
+            PlanAlimentaire(
+                id=row["id"],
+                nom=row["nom"],
+                description=row["description"],
+                tags=row["tags"],
+                repas=[],
+            )
+            for row in rows
+        ]
+
+    def get_plan(self, plan_id: int) -> PlanAlimentaire:
+        with sqlite3.connect(self.db_path) as conn:
+            conn.row_factory = sqlite3.Row
+            plan_row = conn.execute(
+                "SELECT * FROM plans_alimentaires WHERE id = ?", (plan_id,)
+            ).fetchone()
+            if not plan_row:
+                raise ValueError("Plan introuvable")
+            repas_rows = conn.execute(
+                "SELECT * FROM repas WHERE plan_id = ? ORDER BY ordre", (plan_id,)
+            ).fetchall()
+            repas_list = []
+            for rr in repas_rows:
+                items_rows = conn.execute(
+                    "SELECT * FROM repas_items WHERE repas_id = ?", (rr["id"],)
+                ).fetchall()
+                items = [
+                    RepasItem(
+                        id=ir["id"],
+                        repas_id=ir["repas_id"],
+                        aliment_id=ir["aliment_id"],
+                        portion_id=ir["portion_id"],
+                        quantite=ir["quantite"],
+                    )
+                    for ir in items_rows
+                ]
+                repas_list.append(
+                    Repas(
+                        id=rr["id"],
+                        plan_id=rr["plan_id"],
+                        nom=rr["nom"],
+                        ordre=rr["ordre"],
+                        items=items,
+                    )
+                )
+            return PlanAlimentaire(
+                id=plan_row["id"],
+                nom=plan_row["nom"],
+                description=plan_row["description"],
+                tags=plan_row["tags"],
+                repas=repas_list,
+            )
+
+    def create_plan(self, plan: PlanAlimentaire) -> int:
+        with sqlite3.connect(self.db_path) as conn:
+            cur = conn.cursor()
+            cur.execute(
+                "INSERT INTO plans_alimentaires (nom, description, tags) VALUES (?, ?, ?)",
+                (plan.nom, plan.description, plan.tags),
+            )
+            plan_id = cur.lastrowid
+            for repas in plan.repas:
+                cur.execute(
+                    "INSERT INTO repas (plan_id, nom, ordre) VALUES (?, ?, ?)",
+                    (plan_id, repas.nom, repas.ordre),
+                )
+                repas_id = cur.lastrowid
+                for item in repas.items:
+                    cur.execute(
+                        """
+                        INSERT INTO repas_items (repas_id, aliment_id, portion_id, quantite)
+                        VALUES (?, ?, ?, ?)
+                        """,
+                        (repas_id, item.aliment_id, item.portion_id, item.quantite),
+                    )
+            conn.commit()
+            return plan_id
+
+    def update_plan(self, plan: PlanAlimentaire) -> None:
+        with sqlite3.connect(self.db_path) as conn:
+            cur = conn.cursor()
+            cur.execute(
+                "UPDATE plans_alimentaires SET nom = ?, description = ?, tags = ? WHERE id = ?",
+                (plan.nom, plan.description, plan.tags, plan.id),
+            )
+            repas_ids = [r[0] for r in cur.execute("SELECT id FROM repas WHERE plan_id = ?", (plan.id,)).fetchall()]
+            for rid in repas_ids:
+                cur.execute("DELETE FROM repas_items WHERE repas_id = ?", (rid,))
+            cur.execute("DELETE FROM repas WHERE plan_id = ?", (plan.id,))
+            for repas in plan.repas:
+                cur.execute(
+                    "INSERT INTO repas (plan_id, nom, ordre) VALUES (?, ?, ?)",
+                    (plan.id, repas.nom, repas.ordre),
+                )
+                repas_id = cur.lastrowid
+                for item in repas.items:
+                    cur.execute(
+                        """
+                        INSERT INTO repas_items (repas_id, aliment_id, portion_id, quantite)
+                        VALUES (?, ?, ?, ?)
+                        """,
+                        (repas_id, item.aliment_id, item.portion_id, item.quantite),
+                    )
+            conn.commit()
+
+    def delete_plan(self, plan_id: int) -> None:
+        with sqlite3.connect(self.db_path) as conn:
+            cur = conn.cursor()
+            repas_ids = [r[0] for r in cur.execute("SELECT id FROM repas WHERE plan_id = ?", (plan_id,)).fetchall()]
+            for rid in repas_ids:
+                cur.execute("DELETE FROM repas_items WHERE repas_id = ?", (rid,))
+            cur.execute("DELETE FROM repas WHERE plan_id = ?", (plan_id,))
+            cur.execute("DELETE FROM plans_alimentaires WHERE id = ?", (plan_id,))
+            conn.commit()
+
+    # Repas CRUD
+    def add_repas(self, plan_id: int, repas: Repas) -> int:
+        with sqlite3.connect(self.db_path) as conn:
+            cur = conn.cursor()
+            cur.execute(
+                "INSERT INTO repas (plan_id, nom, ordre) VALUES (?, ?, ?)",
+                (plan_id, repas.nom, repas.ordre),
+            )
+            repas_id = cur.lastrowid
+            conn.commit()
+            return repas_id
+
+    def update_repas(self, repas: Repas) -> None:
+        with sqlite3.connect(self.db_path) as conn:
+            cur = conn.cursor()
+            cur.execute(
+                "UPDATE repas SET nom = ?, ordre = ? WHERE id = ?",
+                (repas.nom, repas.ordre, repas.id),
+            )
+            conn.commit()
+
+    def delete_repas(self, repas_id: int) -> None:
+        with sqlite3.connect(self.db_path) as conn:
+            cur = conn.cursor()
+            cur.execute("DELETE FROM repas_items WHERE repas_id = ?", (repas_id,))
+            cur.execute("DELETE FROM repas WHERE id = ?", (repas_id,))
+            conn.commit()
+
+    # Items CRUD
+    def add_item(self, repas_id: int, item: RepasItem) -> int:
+        with sqlite3.connect(self.db_path) as conn:
+            cur = conn.cursor()
+            cur.execute(
+                """
+                INSERT INTO repas_items (repas_id, aliment_id, portion_id, quantite)
+                VALUES (?, ?, ?, ?)
+                """,
+                (repas_id, item.aliment_id, item.portion_id, item.quantite),
+            )
+            item_id = cur.lastrowid
+            conn.commit()
+            return item_id
+
+    def update_item(self, item: RepasItem) -> None:
+        with sqlite3.connect(self.db_path) as conn:
+            cur = conn.cursor()
+            cur.execute(
+                "UPDATE repas_items SET aliment_id = ?, portion_id = ?, quantite = ? WHERE id = ?",
+                (item.aliment_id, item.portion_id, item.quantite, item.id),
+            )
+            conn.commit()
+
+    def delete_item(self, item_id: int) -> None:
+        with sqlite3.connect(self.db_path) as conn:
+            cur = conn.cursor()
+            cur.execute("DELETE FROM repas_items WHERE id = ?", (item_id,))
+            conn.commit()

--- a/ui/layout/sidebar.py
+++ b/ui/layout/sidebar.py
@@ -18,7 +18,7 @@ class Sidebar(ctk.CTkFrame):
             ("sessions", "Séances", "clock.png"),
             ("progress", "Progression", "chart.png"),
             ("pdf", "PDF", "pdf.png"),
-            ("nutrition", "Nutrition", "apple.png"),
+            ("nutrition", "Nutrition", "meal-plan.png"),
             ("database", "Base de données", "database.png"),
             ("clients", "Clients", "users.png"),
             ("messaging", "Messagerie", "chat.png"),

--- a/ui/pages/nutrition_page.py
+++ b/ui/pages/nutrition_page.py
@@ -1,9 +1,269 @@
+import sqlite3
+from typing import Dict, List, Optional
+
 import customtkinter as ctk
-from ui.theme.fonts import get_section_font
+
+from models.plan_alimentaire import PlanAlimentaire, Repas, RepasItem
+from repositories.plan_alimentaire_repo import PlanAlimentaireRepository
+from repositories.aliment_repo import AlimentRepository
+
+DB_PATH = "coach.db"
 
 
 class NutritionPage(ctk.CTkFrame):
     def __init__(self, parent):
         super().__init__(parent)
-        ctk.CTkLabel(self, text="Ma Section", font=get_section_font()).pack()
+        self.plan_repo = PlanAlimentaireRepository()
+        self.aliment_repo = AlimentRepository()
+        self.selected_plan: Optional[PlanAlimentaire] = None
+        self.active_repas_id: Optional[int] = None
+        self.aliments = self.aliment_repo.list_all()
+        self.aliments_by_id = {a.id: a for a in self.aliments}
+
+        self.columnconfigure(0, weight=1)
+        self.columnconfigure(1, weight=3)
+        self.columnconfigure(2, weight=1)
+
+        self._create_left_panel()
+        self._create_center_panel()
+        self._create_right_panel()
+        self._load_plans_list()
+
+    # ----- Left panel -----
+    def _create_left_panel(self) -> None:
+        self.plans_frame = ctk.CTkScrollableFrame(self)
+        self.plans_frame.grid(row=0, column=0, sticky="nsew", padx=5, pady=5)
+        add_btn = ctk.CTkButton(
+            self.plans_frame, text="+", width=40, command=self._create_plan
+        )
+        add_btn.pack(pady=5)
+
+    def _load_plans_list(self) -> None:
+        for widget in self.plans_frame.winfo_children():
+            if isinstance(widget, ctk.CTkButton) and widget.cget("text") != "+":
+                widget.destroy()
+        plans = self.plan_repo.list_plans()
+        for p in plans:
+            btn = ctk.CTkButton(
+                self.plans_frame,
+                text=p.nom,
+                anchor="w",
+                command=lambda pid=p.id: self._load_plan(pid),
+            )
+            btn.pack(fill="x", padx=5, pady=2)
+
+    def _create_plan(self) -> None:
+        new_plan = PlanAlimentaire(id=0, nom="Nouveau plan")
+        plan_id = self.plan_repo.create_plan(new_plan)
+        self._load_plans_list()
+        self._load_plan(plan_id)
+
+    # ----- Center panel -----
+    def _create_center_panel(self) -> None:
+        self.editor_frame = ctk.CTkFrame(self)
+        self.editor_frame.grid(row=0, column=1, sticky="nsew", padx=5, pady=5)
+        self.editor_frame.columnconfigure(0, weight=1)
+
+        self.name_entry = ctk.CTkEntry(self.editor_frame)
+        self.name_entry.grid(row=0, column=0, sticky="ew", pady=(5, 0), padx=5)
+        self.name_entry.bind("<FocusOut>", lambda e: self._save_plan())
+
+        self.desc_text = ctk.CTkTextbox(self.editor_frame, height=80)
+        self.desc_text.grid(row=1, column=0, sticky="nsew", padx=5, pady=5)
+        self.desc_text.bind("<FocusOut>", lambda e: self._save_plan())
+
+        self.totals_label = ctk.CTkLabel(self.editor_frame, text="Totaux: 0 kcal")
+        self.totals_label.grid(row=2, column=0, sticky="w", padx=5)
+
+        self.meals_frame = ctk.CTkScrollableFrame(self.editor_frame)
+        self.meals_frame.grid(row=3, column=0, sticky="nsew", padx=5, pady=5)
+        self.editor_frame.rowconfigure(3, weight=1)
+
+        self.add_meal_btn = ctk.CTkButton(
+            self.editor_frame, text="Ajouter un repas", command=self._add_meal
+        )
+        self.add_meal_btn.grid(row=4, column=0, pady=5)
+
+    def _load_plan(self, plan_id: int) -> None:
+        self.selected_plan = self.plan_repo.get_plan(plan_id)
+        self.active_repas_id = None
+        self.name_entry.delete(0, "end")
+        self.name_entry.insert(0, self.selected_plan.nom)
+        self.desc_text.delete("1.0", "end")
+        if self.selected_plan.description:
+            self.desc_text.insert("1.0", self.selected_plan.description)
+        self._refresh_meals()
+        self._update_totals()
+
+    def _save_plan(self) -> None:
+        if not self.selected_plan:
+            return
+        self.selected_plan.nom = self.name_entry.get()
+        self.selected_plan.description = self.desc_text.get("1.0", "end").strip()
+        self.plan_repo.update_plan(self.selected_plan)
+        self._load_plans_list()
+
+    def _refresh_meals(self) -> None:
+        for widget in self.meals_frame.winfo_children():
+            widget.destroy()
+        if not self.selected_plan:
+            return
+        for repas in self.selected_plan.repas:
+            self._create_meal_card(repas)
+
+    def _create_meal_card(self, repas: Repas) -> None:
+        frame = ctk.CTkFrame(self.meals_frame, border_width=2)
+        frame.pack(fill="x", pady=5, padx=5)
+        frame.bind("<Button-1>", lambda e, rid=repas.id: self._set_active_meal(rid, frame))
+
+        header = ctk.CTkFrame(frame, fg_color="transparent")
+        header.pack(fill="x")
+        name_lbl = ctk.CTkLabel(header, text=repas.nom)
+        name_lbl.pack(side="left", padx=5)
+        totals = self._compute_meal_totals(repas)
+        totals_lbl = ctk.CTkLabel(
+            header,
+            text=f"{totals['kcal']:.0f} kcal P{totals['proteines']:.1f} G{totals['glucides']:.1f} L{totals['lipides']:.1f}",
+        )
+        totals_lbl.pack(side="left", padx=5)
+        add_btn = ctk.CTkButton(header, text="+", width=30, command=lambda rid=repas.id: self._set_active_meal(rid, frame))
+        add_btn.pack(side="right", padx=5)
+
+        items_frame = ctk.CTkFrame(frame, fg_color="transparent")
+        items_frame.pack(fill="x", padx=10, pady=5)
+        for item in repas.items:
+            aliment = self.aliments_by_id.get(item.aliment_id)
+            portion = self._get_portion(item.portion_id)
+            item_lbl = ctk.CTkLabel(
+                items_frame,
+                text=f"{aliment.nom} - {portion['description']} x{item.quantite}",
+                anchor="w",
+            )
+            item_lbl.pack(fill="x")
+
+    def _set_active_meal(self, repas_id: int, frame: ctk.CTkFrame) -> None:
+        self.active_repas_id = repas_id
+        for child in self.meals_frame.winfo_children():
+            child.configure(border_color=self.meals_frame.cget("fg_color"))
+        frame.configure(border_color=ctk.ThemeManager.theme["CTkButton"]["fg_color"]["normal"])  # primary color
+
+    def _add_meal(self) -> None:
+        if not self.selected_plan:
+            return
+        repas = Repas(id=0, plan_id=self.selected_plan.id, nom="Nouveau repas", ordre=len(self.selected_plan.repas))
+        self.plan_repo.add_repas(self.selected_plan.id, repas)
+        self._load_plan(self.selected_plan.id)
+
+    # ----- Right panel -----
+    def _create_right_panel(self) -> None:
+        self.library_frame = ctk.CTkFrame(self)
+        self.library_frame.grid(row=0, column=2, sticky="nsew", padx=5, pady=5)
+        self.library_frame.columnconfigure(0, weight=1)
+
+        self.search_var = ctk.StringVar()
+        search_entry = ctk.CTkEntry(
+            self.library_frame, textvariable=self.search_var
+        )
+        search_entry.grid(row=0, column=0, sticky="ew", padx=5, pady=5)
+        self.search_var.trace_add("write", lambda *args: self._update_library())
+
+        self.results_frame = ctk.CTkScrollableFrame(self.library_frame)
+        self.results_frame.grid(row=1, column=0, sticky="nsew", padx=5, pady=5)
+        self.library_frame.rowconfigure(1, weight=1)
+        self._update_library()
+
+    def _update_library(self) -> None:
+        for widget in self.results_frame.winfo_children():
+            widget.destroy()
+        query = self.search_var.get().lower()
+        for aliment in self.aliments:
+            if query and query not in aliment.nom.lower():
+                continue
+            btn = ctk.CTkButton(
+                self.results_frame,
+                text=aliment.nom,
+                anchor="w",
+                command=lambda a=aliment: self._open_add_item_popup(a),
+            )
+            btn.pack(fill="x", padx=5, pady=2)
+
+    def _open_add_item_popup(self, aliment) -> None:
+        if self.active_repas_id is None:
+            return
+        portions = self.aliment_repo.get_portions_for_aliment(aliment.id)
+        popup = ctk.CTkToplevel(self)
+        popup.title(aliment.nom)
+        popup.grab_set()
+
+        portion_var = ctk.StringVar(value=str(portions[0].id))
+        portion_menu = ctk.CTkOptionMenu(
+            popup,
+            values=[f"{p.description} ({p.grammes_equivalents}g)" for p in portions],
+            variable=portion_var,
+        )
+        portion_menu.pack(padx=10, pady=10)
+
+        qty_entry = ctk.CTkEntry(popup)
+        qty_entry.insert(0, "1.0")
+        qty_entry.pack(padx=10, pady=10)
+
+        def add_action():
+            try:
+                qty = float(qty_entry.get())
+            except ValueError:
+                qty = 1.0
+            portion = portions[portion_menu._current_index]
+            item = RepasItem(id=0, repas_id=self.active_repas_id, aliment_id=aliment.id, portion_id=portion.id, quantite=qty)
+            self.plan_repo.add_item(self.active_repas_id, item)
+            self._load_plan(self.selected_plan.id)
+            popup.destroy()
+
+        add_btn = ctk.CTkButton(popup, text="Ajouter", command=add_action)
+        add_btn.pack(pady=10)
+
+    # ----- Totals -----
+    def _get_portion(self, portion_id: int) -> sqlite3.Row:
+        with sqlite3.connect(DB_PATH) as conn:
+            conn.row_factory = sqlite3.Row
+            row = conn.execute("SELECT * FROM portions WHERE id = ?", (portion_id,)).fetchone()
+        return row
+
+    def _compute_item_totals(self, item: RepasItem) -> Dict[str, float]:
+        with sqlite3.connect(DB_PATH) as conn:
+            conn.row_factory = sqlite3.Row
+            aliment = conn.execute("SELECT * FROM aliments WHERE id = ?", (item.aliment_id,)).fetchone()
+            portion = conn.execute("SELECT * FROM portions WHERE id = ?", (item.portion_id,)).fetchone()
+        facteur = (portion["grammes_equivalents"] * item.quantite) / 100
+        return {
+            "kcal": aliment["kcal_100g"] * facteur,
+            "proteines": aliment["proteines_100g"] * facteur,
+            "glucides": aliment["glucides_100g"] * facteur,
+            "lipides": aliment["lipides_100g"] * facteur,
+        }
+
+    def _compute_meal_totals(self, repas: Repas) -> Dict[str, float]:
+        totals = {"kcal": 0.0, "proteines": 0.0, "glucides": 0.0, "lipides": 0.0}
+        for item in repas.items:
+            it = self._compute_item_totals(item)
+            for k in totals:
+                totals[k] += it[k]
+        return totals
+
+    def _update_totals(self) -> None:
+        if not self.selected_plan:
+            self.totals_label.configure(text="Totaux: 0 kcal")
+            return
+        totals = {"kcal": 0.0, "proteines": 0.0, "glucides": 0.0, "lipides": 0.0}
+        for repas in self.selected_plan.repas:
+            mt = self._compute_meal_totals(repas)
+            for k in totals:
+                totals[k] += mt[k]
+        self.totals_label.configure(
+            text=(
+                f"Totaux: {totals['kcal']:.0f} kcal "
+                f"P{totals['proteines']:.1f} "
+                f"G{totals['glucides']:.1f} "
+                f"L{totals['lipides']:.1f}"
+            )
+        )
 


### PR DESCRIPTION
## Summary
- expand database schema with meal plan, meal, and item tables
- support fetching aliment portions and CRUD for meal plans
- build NutritionPage editor with real-time nutrition totals
- swap sidebar nutrition icon to meal-plan graphic and update navigation title

## Testing
- `python -m py_compile app.py repositories/aliment_repo.py repositories/plan_alimentaire_repo.py models/plan_alimentaire.py ui/pages/nutrition_page.py ui/layout/sidebar.py`


------
https://chatgpt.com/codex/tasks/task_e_689f1ed6f644832aa2cf2f8181eec0c1