### PR TITLE
Fix exercise attribute name in session generator

### DIFF
--- a/services/session_generator.py
+++ b/services/session_generator.py
@@ -92,7 +92,7 @@ def build_block(slot: Dict[str, Any], pool: List[Exercise], rng: random.Random, 
             presc = {"work_sec": block.work_sec, "rest_sec": block.rest_sec}
         else:
             presc = {}
-        block.items.append(BlockItem(exercise_id=ex.exercise_id, prescription=presc))
+        block.items.append(BlockItem(exercise_id=ex.id, prescription=presc))
         last_pattern = ex.movement_pattern
     return block
 


### PR DESCRIPTION
## Summary
- Correct the exercise ID attribute used when appending block items

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_689f281ff648832aad0d4b182c3bc461