### PR TITLE
Add get_exclusions method to ClientRepository

### DIFF
--- a/repositories/client_repo.py
+++ b/repositories/client_repo.py
@@ -108,3 +108,14 @@ class ClientRepository:
             )
         conn.commit()
         conn.close()
+
+    def get_exclusions(self, client_id: int) -> List[int]:
+        conn = self._get_connection()
+        cursor = conn.cursor()
+        cursor.execute(
+            "SELECT exercice_id FROM client_exercice_exclusions WHERE client_id = ?",
+            (client_id,),
+        )
+        rows = cursor.fetchall()
+        conn.close()
+        return [row["exercice_id"] for row in rows]


### PR DESCRIPTION
## Summary
- Implement missing `get_exclusions` in `ClientRepository` to fetch excluded exercise IDs for a client

## Testing
- `python -m py_compile repositories/client_repo.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689f30991340832a89da4e7607f5ac01