### PR TITLE
feat: add nutrition sheet module

### DIFF
--- a/db/schema.sql
+++ b/db/schema.sql
@@ -24,7 +24,11 @@ CREATE TABLE clients (
     email TEXT UNIQUE,
     date_naissance DATE,
     objectifs TEXT,
-    antecedents_medicaux TEXT
+    antecedents_medicaux TEXT,
+    sexe TEXT,
+    poids_kg REAL,
+    taille_cm REAL,
+    niveau_activite TEXT
 );
 
 CREATE TABLE client_exercice_exclusions (
@@ -103,5 +107,21 @@ CREATE TABLE repas_items (
     FOREIGN KEY(repas_id) REFERENCES repas(id),
     FOREIGN KEY(aliment_id) REFERENCES aliments(id),
     FOREIGN KEY(portion_id) REFERENCES portions(id)
+);
+
+CREATE TABLE fiches_nutrition (
+    id INTEGER PRIMARY KEY,
+    client_id INTEGER NOT NULL,
+    date_creation DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    poids_kg_mesure REAL NOT NULL,
+    objectif TEXT NOT NULL,
+    proteines_cible_g_par_kg REAL NOT NULL,
+    ratio_glucides_lipides_cible REAL NOT NULL,
+    maintenance_kcal INTEGER NOT NULL,
+    objectif_kcal INTEGER NOT NULL,
+    proteines_g INTEGER NOT NULL,
+    glucides_g INTEGER NOT NULL,
+    lipides_g INTEGER NOT NULL,
+    FOREIGN KEY(client_id) REFERENCES clients(id)
 );
 

--- a/models/__init__.py
+++ b/models/__init__.py
@@ -1,3 +1,4 @@
 from .client import Client
 from .seance import Seance
 from .resultat_exercice import ResultatExercice
+from .fiche_nutrition import FicheNutrition

--- a/models/client.py
+++ b/models/client.py
@@ -11,3 +11,7 @@ class Client:
     date_naissance: Optional[str] = None
     objectifs: Optional[str] = None
     antecedents_medicaux: Optional[str] = None
+    sexe: Optional[str] = None
+    poids_kg: Optional[float] = None
+    taille_cm: Optional[float] = None
+    niveau_activite: Optional[str] = None

--- a/models/fiche_nutrition.py
+++ b/models/fiche_nutrition.py
@@ -1,0 +1,18 @@
+from dataclasses import dataclass
+from typing import Optional
+
+
+@dataclass
+class FicheNutrition:
+    id: Optional[int]
+    client_id: int
+    date_creation: Optional[str]
+    poids_kg_mesure: float
+    objectif: str
+    proteines_cible_g_par_kg: float
+    ratio_glucides_lipides_cible: float
+    maintenance_kcal: int
+    objectif_kcal: int
+    proteines_g: int
+    glucides_g: int
+    lipides_g: int

--- a/repositories/client_repo.py
+++ b/repositories/client_repo.py
@@ -31,6 +31,10 @@ class ClientRepository:
                     date_naissance=row["date_naissance"],
                     objectifs=row["objectifs"],
                     antecedents_medicaux=row["antecedents_medicaux"],
+                    sexe=row["sexe"],
+                    poids_kg=row["poids_kg"],
+                    taille_cm=row["taille_cm"],
+                    niveau_activite=row["niveau_activite"],
                 )
             )
         return clients
@@ -51,6 +55,10 @@ class ClientRepository:
                 date_naissance=row["date_naissance"],
                 objectifs=row["objectifs"],
                 antecedents_medicaux=row["antecedents_medicaux"],
+                sexe=row["sexe"],
+                poids_kg=row["poids_kg"],
+                taille_cm=row["taille_cm"],
+                niveau_activite=row["niveau_activite"],
             )
         return None
 

--- a/repositories/fiche_nutrition_repo.py
+++ b/repositories/fiche_nutrition_repo.py
@@ -1,0 +1,67 @@
+import sqlite3
+from typing import Optional
+
+from models.fiche_nutrition import FicheNutrition
+
+DB_PATH = "coach.db"
+
+
+class FicheNutritionRepository:
+    def __init__(self, db_path: str = DB_PATH):
+        self.db_path = db_path
+
+    def _get_conn(self):
+        conn = sqlite3.connect(self.db_path)
+        conn.row_factory = sqlite3.Row
+        return conn
+
+    def add(self, fiche: FicheNutrition) -> int:
+        with self._get_conn() as conn:
+            cur = conn.cursor()
+            cur.execute(
+                """
+                INSERT INTO fiches_nutrition (
+                    client_id, poids_kg_mesure, objectif,
+                    proteines_cible_g_par_kg, ratio_glucides_lipides_cible,
+                    maintenance_kcal, objectif_kcal,
+                    proteines_g, glucides_g, lipides_g
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    fiche.client_id,
+                    fiche.poids_kg_mesure,
+                    fiche.objectif,
+                    fiche.proteines_cible_g_par_kg,
+                    fiche.ratio_glucides_lipides_cible,
+                    fiche.maintenance_kcal,
+                    fiche.objectif_kcal,
+                    fiche.proteines_g,
+                    fiche.glucides_g,
+                    fiche.lipides_g,
+                ),
+            )
+            conn.commit()
+            return cur.lastrowid
+
+    def get_last_for_client(self, client_id: int) -> Optional[FicheNutrition]:
+        with self._get_conn() as conn:
+            row = conn.execute(
+                "SELECT * FROM fiches_nutrition WHERE client_id = ? ORDER BY date_creation DESC LIMIT 1",
+                (client_id,),
+            ).fetchone()
+            if not row:
+                return None
+            return FicheNutrition(
+                id=row["id"],
+                client_id=row["client_id"],
+                date_creation=row["date_creation"],
+                poids_kg_mesure=row["poids_kg_mesure"],
+                objectif=row["objectif"],
+                proteines_cible_g_par_kg=row["proteines_cible_g_par_kg"],
+                ratio_glucides_lipides_cible=row["ratio_glucides_lipides_cible"],
+                maintenance_kcal=row["maintenance_kcal"],
+                objectif_kcal=row["objectif_kcal"],
+                proteines_g=row["proteines_g"],
+                glucides_g=row["glucides_g"],
+                lipides_g=row["lipides_g"],
+            )

--- a/services/nutrition_service.py
+++ b/services/nutrition_service.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+from typing import Dict
+
+
+ACTIVITY_FACTORS = {
+    "Sédentaire": 1.2,
+    "Activité légère": 1.375,
+    "Activité modérée": 1.55,
+    "Très actif": 1.725,
+    "Extrêmement actif": 1.9,
+}
+
+OBJECTIVE_ADJUST = {
+    "Perte de poids": -300,
+    "Maintenance": 0,
+    "Prise de masse": 300,
+}
+
+
+def _bmr(data: Dict) -> float:
+    poids = data["poids_kg"]
+    taille = data["taille_cm"]
+    age = data["age"]
+    sexe = data["sexe"].lower()
+    base = 10 * poids + 6.25 * taille - 5 * age
+    if sexe.startswith("h"):
+        base += 5
+    else:
+        base -= 161
+    return base
+
+
+def calculate_nutrition_targets(data: Dict) -> Dict:
+    proteines_g_par_kg = float(data.get("proteines_g_par_kg", 1.8))
+    ratio_glucides = data.get("ratio_glucides")
+
+    bmr = _bmr(data)
+    factor = ACTIVITY_FACTORS.get(data["niveau_activite"], 1.2)
+    maintenance = bmr * factor
+
+    adj = OBJECTIVE_ADJUST.get(data["objectif"], 0)
+    objectif_kcal = maintenance + adj
+
+    # Proteins
+    proteines_g = round(proteines_g_par_kg * data["poids_kg"])
+    protein_cal = proteines_g * 4
+
+    if ratio_glucides is not None:
+        ratio_glucides = float(ratio_glucides)
+        remaining = objectif_kcal - protein_cal
+        carbs_cal = remaining * (ratio_glucides / 100)
+        lipids_cal = remaining - carbs_cal
+        glucides_g = round(carbs_cal / 4)
+        lipides_g = round(lipids_cal / 9)
+    else:
+        lipides_g = round(data["poids_kg"])
+        lipids_cal = lipides_g * 9
+        remaining = objectif_kcal - protein_cal - lipids_cal
+        glucides_g = round(remaining / 4)
+        carbs_cal = glucides_g * 4
+        remaining_total = objectif_kcal - protein_cal
+        ratio_glucides = (carbs_cal / remaining_total * 100) if remaining_total > 0 else 0
+
+    return {
+        "maintenance_kcal": round(maintenance),
+        "objectif_kcal": round(objectif_kcal),
+        "proteines_g": proteines_g,
+        "glucides_g": glucides_g,
+        "lipides_g": lipides_g,
+        "proteines_cible_g_par_kg": proteines_g_par_kg,
+        "ratio_glucides_lipides_cible": round(ratio_glucides, 2),
+    }

--- a/services/pdf_generator.py
+++ b/services/pdf_generator.py
@@ -1,0 +1,57 @@
+from io import BytesIO
+
+from reportlab.lib.pagesizes import A4
+from reportlab.pdfgen import canvas
+from reportlab.lib.utils import ImageReader
+from matplotlib.figure import Figure
+
+from models.client import Client
+from ui.theme.colors import PRIMARY, SECONDARY, TEXT_MUTED, DARK_BG, DARK_PANEL, TEXT
+
+
+def generate_nutrition_sheet_pdf(fiche_data: dict, client_data: Client, file_path: str) -> None:
+    c = canvas.Canvas(file_path, pagesize=A4)
+    width, height = A4
+
+    c.setTitle("Fiche Nutrition")
+    c.setFont("Helvetica-Bold", 16)
+    c.drawString(30, height - 40, f"Fiche Nutrition - {client_data.prenom} {client_data.nom}")
+
+    c.setFont("Helvetica", 12)
+    y = height - 80
+    c.drawString(30, y, f"Poids mesuré : {fiche_data['poids_kg_mesure']} kg")
+    y -= 20
+    c.drawString(30, y, f"Objectif : {fiche_data['objectif']}")
+    y -= 20
+    c.drawString(30, y, f"Maintenance : {fiche_data['maintenance_kcal']} kcal")
+    y -= 20
+    c.drawString(30, y, f"Objectif calorique : {fiche_data['objectif_kcal']} kcal")
+    y -= 30
+    c.drawString(30, y, f"Protéines : {fiche_data['proteines_g']} g")
+    y -= 20
+    c.drawString(30, y, f"Glucides : {fiche_data['glucides_g']} g")
+    y -= 20
+    c.drawString(30, y, f"Lipides : {fiche_data['lipides_g']} g")
+
+    # Pie chart
+    fig = Figure(figsize=(2.5, 2.5), dpi=100)
+    fig.patch.set_facecolor(DARK_PANEL)
+    ax = fig.add_subplot(111)
+    ax.set_facecolor(DARK_BG)
+    total = fiche_data['objectif_kcal']
+    protein_cal = fiche_data['proteines_g'] * 4
+    carbs_cal = fiche_data['glucides_g'] * 4
+    fats_cal = fiche_data['lipides_g'] * 9
+    ax.pie(
+        [protein_cal, carbs_cal, fats_cal],
+        colors=[PRIMARY, SECONDARY, TEXT_MUTED],
+        labels=["P", "G", "L"],
+        textprops={"color": TEXT},
+    )
+    buf = BytesIO()
+    fig.savefig(buf, format="PNG", facecolor=DARK_PANEL)
+    buf.seek(0)
+    c.drawImage(ImageReader(buf), width - 180, height - 220, 150, 150)
+
+    c.showPage()
+    c.save()

--- a/ui/pages/client_detail_page.py
+++ b/ui/pages/client_detail_page.py
@@ -6,6 +6,9 @@ from ui.theme.colors import DARK_BG, TEXT
 from ui.pages.client_detail_page_components.anamnese_tab import AnamneseTab
 from ui.pages.client_detail_page_components.suivi_tab import SuiviTab
 from ui.pages.client_detail_page_components.stats_tab import StatsTab
+from ui.pages.client_detail_page_components.fiche_nutrition_tab import (
+    FicheNutritionTab,
+)
 
 
 class ClientDetailPage(ctk.CTkFrame):
@@ -45,4 +48,6 @@ class ClientDetailPage(ctk.CTkFrame):
         SuiviTab(suivi_tab, self.client_id).pack(fill="both", expand=True, padx=10, pady=10)
         stats_tab = tabview.add("Progression & Stats")
         StatsTab(stats_tab, self.client_id).pack(fill="both", expand=True, padx=10, pady=10)
+        fiche_tab = tabview.add("Fiche Nutrition")
+        FicheNutritionTab(fiche_tab, self.client_id).pack(fill="both", expand=True, padx=10, pady=10)
 

--- a/ui/pages/client_detail_page_components/fiche_nutrition_tab.py
+++ b/ui/pages/client_detail_page_components/fiche_nutrition_tab.py
@@ -1,0 +1,180 @@
+import datetime
+from dataclasses import asdict
+
+import customtkinter as ctk
+from tkinter import filedialog
+
+from repositories.fiche_nutrition_repo import FicheNutritionRepository
+from repositories.client_repo import ClientRepository
+from services.nutrition_service import (
+    calculate_nutrition_targets,
+    ACTIVITY_FACTORS,
+    OBJECTIVE_ADJUST,
+)
+from services.pdf_generator import generate_nutrition_sheet_pdf
+from models.fiche_nutrition import FicheNutrition
+from ui.theme.colors import DARK_PANEL, TEXT
+from ui.theme.fonts import get_title_font
+
+
+class FicheNutritionTab(ctk.CTkFrame):
+    def __init__(self, master, client_id: int):
+        super().__init__(master, fg_color="transparent")
+        self.client_id = client_id
+        self.repo = FicheNutritionRepository()
+        self.client_repo = ClientRepository()
+        self.client = self.client_repo.find_by_id(client_id)
+        self.fiche = self.repo.get_last_for_client(client_id)
+
+        self.display = ctk.CTkFrame(self, fg_color=DARK_PANEL)
+        self.display.pack(fill="both", expand=True, padx=10, pady=10)
+
+        btn_frame = ctk.CTkFrame(self, fg_color="transparent")
+        btn_frame.pack(pady=10)
+        ctk.CTkButton(btn_frame, text="Générer / Mettre à jour", command=self.open_modal).pack(side="left", padx=5)
+        self.export_btn = ctk.CTkButton(btn_frame, text="Exporter en PDF", command=self.export_pdf)
+        self.export_btn.pack(side="left", padx=5)
+
+        self.refresh()
+
+    def refresh(self):
+        for w in self.display.winfo_children():
+            w.destroy()
+        if not self.fiche:
+            ctk.CTkLabel(self.display, text="Aucune fiche nutrition", text_color=TEXT).pack(expand=True)
+            self.export_btn.configure(state="disabled")
+        else:
+            self.export_btn.configure(state="normal")
+            ctk.CTkLabel(self.display, text="Dernière fiche", font=get_title_font(), text_color=TEXT).pack(anchor="w", padx=10, pady=(10, 20))
+            info = (
+                f"Date : {self.fiche.date_creation}\n"
+                f"Objectif : {self.fiche.objectif}\n"
+                f"Maintenance : {self.fiche.maintenance_kcal} kcal\n"
+                f"Objectif : {self.fiche.objectif_kcal} kcal\n"
+                f"Protéines : {self.fiche.proteines_g} g\n"
+                f"Glucides : {self.fiche.glucides_g} g\n"
+                f"Lipides : {self.fiche.lipides_g} g"
+            )
+            ctk.CTkLabel(self.display, text=info, text_color=TEXT, justify="left").pack(anchor="w", padx=10, pady=(0, 10))
+
+    # Modal
+    def open_modal(self):
+        GenerateFicheModal(self)
+
+    def export_pdf(self):
+        if not self.fiche or not self.client:
+            return
+        path = filedialog.asksaveasfilename(defaultextension=".pdf", filetypes=[("PDF", "*.pdf")])
+        if path:
+            generate_nutrition_sheet_pdf(asdict(self.fiche), self.client, path)
+
+
+class GenerateFicheModal(ctk.CTkToplevel):
+    def __init__(self, parent: FicheNutritionTab):
+        super().__init__(parent)
+        self.parent = parent
+        self.title("Générer une fiche")
+        self.geometry("400x600")
+
+        c = parent.client
+        self.poids_var = ctk.StringVar(value=str(c.poids_kg or ""))
+        self.taille_var = ctk.StringVar(value=str(c.taille_cm or ""))
+        self.date_var = ctk.StringVar(value=c.date_naissance or "")
+        self.sexe_var = ctk.StringVar(value=c.sexe or "Homme")
+        self.activite_var = ctk.StringVar(value=c.niveau_activite or "Sédentaire")
+        self.obj_var = ctk.StringVar(value="Maintenance")
+        self.prot_var = ctk.DoubleVar(value=1.8)
+        self.ratio_var = ctk.DoubleVar(value=self._default_ratio())
+
+        frame = ctk.CTkFrame(self)
+        frame.pack(fill="both", expand=True, padx=20, pady=20)
+
+        def add_entry(label, var):
+            ctk.CTkLabel(frame, text=label, text_color=TEXT).pack(anchor="w")
+            ctk.CTkEntry(frame, textvariable=var).pack(fill="x", pady=(0, 10))
+
+        add_entry("Poids (kg)", self.poids_var)
+        add_entry("Taille (cm)", self.taille_var)
+        add_entry("Date de naissance (AAAA-MM-JJ)", self.date_var)
+
+        ctk.CTkLabel(frame, text="Sexe", text_color=TEXT).pack(anchor="w")
+        ctk.CTkOptionMenu(frame, variable=self.sexe_var, values=["Homme", "Femme"]).pack(fill="x", pady=(0, 10))
+
+        ctk.CTkLabel(frame, text="Niveau d'activité", text_color=TEXT).pack(anchor="w")
+        ctk.CTkOptionMenu(
+            frame,
+            variable=self.activite_var,
+            values=list(ACTIVITY_FACTORS.keys()),
+        ).pack(fill="x", pady=(0, 10))
+
+        ctk.CTkLabel(frame, text="Objectif", text_color=TEXT).pack(anchor="w")
+        ctk.CTkOptionMenu(
+            frame,
+            variable=self.obj_var,
+            values=list(OBJECTIVE_ADJUST.keys()),
+        ).pack(fill="x", pady=(0, 10))
+
+        ctk.CTkLabel(frame, text="Protéines (g/kg)", text_color=TEXT).pack(anchor="w")
+        ctk.CTkSlider(frame, from_=1.0, to=3.0, number_of_steps=20, variable=self.prot_var).pack(fill="x", pady=(0, 10))
+
+        ctk.CTkLabel(frame, text="Répartition G/L (%)", text_color=TEXT).pack(anchor="w")
+        ctk.CTkSlider(frame, from_=0, to=100, number_of_steps=100, variable=self.ratio_var).pack(fill="x", pady=(0, 10))
+
+        ctk.CTkButton(self, text="Générer", command=self.generate).pack(pady=10)
+
+    def _default_ratio(self) -> float:
+        try:
+            data = {
+                "poids_kg": float(self.parent.client.poids_kg or 0),
+                "taille_cm": float(self.parent.client.taille_cm or 0),
+                "age": self._age(self.parent.client.date_naissance),
+                "sexe": self.parent.client.sexe or "Homme",
+                "niveau_activite": self.parent.client.niveau_activite or "Sédentaire",
+                "objectif": "Maintenance",
+            }
+            res = calculate_nutrition_targets(data)
+            return res["ratio_glucides_lipides_cible"]
+        except Exception:
+            return 50.0
+
+    def _age(self, date_str: str | None) -> int:
+        if not date_str:
+            return 0
+        try:
+            birth = datetime.date.fromisoformat(date_str)
+            today = datetime.date.today()
+            return today.year - birth.year - ((today.month, today.day) < (birth.month, birth.day))
+        except Exception:
+            return 0
+
+    def generate(self):
+        age = self._age(self.date_var.get())
+        data = {
+            "poids_kg": float(self.poids_var.get()),
+            "taille_cm": float(self.taille_var.get()),
+            "age": age,
+            "sexe": self.sexe_var.get(),
+            "niveau_activite": self.activite_var.get(),
+            "objectif": self.obj_var.get(),
+            "proteines_g_par_kg": float(self.prot_var.get()),
+            "ratio_glucides": float(self.ratio_var.get()),
+        }
+        targets = calculate_nutrition_targets(data)
+        fiche = FicheNutrition(
+            id=None,
+            client_id=self.parent.client_id,
+            date_creation=None,
+            poids_kg_mesure=data["poids_kg"],
+            objectif=data["objectif"],
+            proteines_cible_g_par_kg=targets["proteines_cible_g_par_kg"],
+            ratio_glucides_lipides_cible=targets["ratio_glucides_lipides_cible"],
+            maintenance_kcal=targets["maintenance_kcal"],
+            objectif_kcal=targets["objectif_kcal"],
+            proteines_g=targets["proteines_g"],
+            glucides_g=targets["glucides_g"],
+            lipides_g=targets["lipides_g"],
+        )
+        self.parent.repo.add(fiche)
+        self.parent.fiche = self.parent.repo.get_last_for_client(self.parent.client_id)
+        self.parent.refresh()
+        self.destroy()

--- a/ui/theme/colors.py
+++ b/ui/theme/colors.py
@@ -12,6 +12,7 @@ DARK_SOFT = "#2a2a2d"       # Bloc secondaire ou éléments passifs
 # Texte
 TEXT = "#f9f9f9"            # Texte principal (anciennement #f5f5f5)
 TEXT_SECONDARY = "#bbbbbb"  # Texte secondaire
+TEXT_MUTED = "#999999"     # Texte atténué
 
 # Accent
 SUCCESS = "#22c55e"


### PR DESCRIPTION
## Summary
- expand database for client metrics and nutrition sheets
- compute flexible nutrition targets and export styled PDF
- add nutrition tab in client detail with generation modal

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_689f36a3efa0832ab4c95fc47c13b2e1