### PR TITLE
feat: persist client form and refresh list

### DIFF
--- a/ui/modals/client_form_modal.py
+++ b/ui/modals/client_form_modal.py
@@ -1,7 +1,9 @@
 import customtkinter as ctk
 from typing import Optional
+from tkinter import messagebox
 
 from models.client import Client
+from repositories.client_repo import ClientRepository
 from ui.theme.fonts import get_title_font, get_text_font
 from ui.theme.colors import DARK_BG, TEXT
 
@@ -60,11 +62,31 @@ class ClientFormModal(ctk.CTkToplevel):
         ctk.CTkButton(btn_frame, text="Annuler", command=self.destroy).pack(side="left", padx=5)
 
     def _on_save(self) -> None:
-        data = {
-            "prenom": self.prenom_var.get(),
-            "nom": self.nom_var.get(),
-            "email": self.email_var.get(),
-            "date_naissance": self.date_var.get(),
-        }
-        print("Enregistrer client:", data)
+        prenom = self.prenom_var.get().strip()
+        nom = self.nom_var.get().strip()
+        email = self.email_var.get().strip() or None
+        date_naissance = self.date_var.get().strip() or None
+
+        if not prenom or not nom:
+            messagebox.showerror("Erreur", "Le nom et le prénom sont obligatoires.")
+            return
+
+        repo = ClientRepository()
+
+        if self.client:
+            self.client.prenom = prenom
+            self.client.nom = nom
+            self.client.email = email
+            self.client.date_naissance = date_naissance
+            repo.update(self.client)
+        else:
+            nouveau_client = Client(
+                id=None,
+                prenom=prenom,
+                nom=nom,
+                email=email,
+                date_naissance=date_naissance,
+            )
+            repo.add(nouveau_client)
+
         self.destroy()

--- a/ui/pages/clients_page.py
+++ b/ui/pages/clients_page.py
@@ -26,15 +26,15 @@ class ClientsPage(ctk.CTkFrame):
         actions.pack(fill="x", padx=20)
 
         ctk.CTkButton(actions, text="Ajouter un client", command=self._open_add_modal).pack(side="left", padx=(0, 10))
-        ctk.CTkButton(actions, text="Rafraîchir", command=self.load_clients).pack(side="left")
+        ctk.CTkButton(actions, text="Rafraîchir", command=self._load_clients).pack(side="left")
 
         self.scroll = ctk.CTkScrollableFrame(self, fg_color="transparent")
         self.scroll.pack(fill="both", expand=True, padx=20, pady=20)
 
-        self.load_clients()
+        self._load_clients()
 
     # -- Data loading -----------------------------------------------------
-    def load_clients(self) -> None:
+    def _load_clients(self) -> None:
         """Charge et affiche les clients dans le scroll frame."""
         for widget in self.scroll.winfo_children():
             widget.destroy()
@@ -77,10 +77,10 @@ class ClientsPage(ctk.CTkFrame):
         modal = ClientFormModal(self)
         modal.grab_set()
         self.wait_window(modal)
-        self.load_clients()
+        self._load_clients()
 
     def _open_edit_modal(self, client: Client) -> None:
         modal = ClientFormModal(self, client)
         modal.grab_set()
         self.wait_window(modal)
-        self.load_clients()
+        self._load_clients()


### PR DESCRIPTION
## Summary
- persist new or edited clients from the ClientFormModal
- refresh clients list after closing client modals

## Testing
- `pytest`
- `python -m py_compile ui/modals/client_form_modal.py ui/pages/clients_page.py`


------
https://chatgpt.com/codex/tasks/task_e_689f5def2e74832a83a808421b7d700a