### PR TITLE
Refactor client detail UI using design system components

### DIFF
--- a/ui/components/design_system/__init__.py
+++ b/ui/components/design_system/__init__.py
@@ -1,5 +1,6 @@
-from .buttons import PrimaryButton
+from .buttons import PrimaryButton, SecondaryButton
 from .cards import Card
+from .typography import PageTitle, CardTitle
 
-__all__ = ["PrimaryButton", "Card"]
+__all__ = ["PrimaryButton", "SecondaryButton", "Card", "PageTitle", "CardTitle"]
 

--- a/ui/components/design_system/buttons.py
+++ b/ui/components/design_system/buttons.py
@@ -2,7 +2,7 @@
 
 import customtkinter as ctk
 
-from ui.theme.colors import PRIMARY, SECONDARY, TEXT_ON_PRIMARY
+from ui.theme.colors import PRIMARY, SECONDARY, TEXT_ON_PRIMARY, DARK_SOFT
 from ui.theme.fonts import get_button_font
 
 
@@ -15,6 +15,24 @@ class PrimaryButton(ctk.CTkButton):
             fg_color=PRIMARY,
             hover_color=SECONDARY,
             text_color=TEXT_ON_PRIMARY,
+            font=get_button_font(),
+            corner_radius=8,
+            height=40,
+            **kwargs,
+        )
+
+
+class SecondaryButton(ctk.CTkButton):
+    """Bouton pour les actions secondaires (retour, annuler, etc.)."""
+
+    def __init__(self, master, **kwargs):
+        super().__init__(
+            master,
+            fg_color="transparent",
+            hover_color=DARK_SOFT,
+            text_color=PRIMARY,
+            border_width=1,
+            border_color=PRIMARY,
             font=get_button_font(),
             corner_radius=8,
             height=40,

--- a/ui/components/design_system/typography.py
+++ b/ui/components/design_system/typography.py
@@ -1,0 +1,20 @@
+# ui/components/design_system/typography.py
+
+import customtkinter as ctk
+
+from ui.theme.colors import TEXT
+from ui.theme.fonts import get_title_font, get_section_font
+
+
+class PageTitle(ctk.CTkLabel):
+    """Titre principal pour les pages."""
+
+    def __init__(self, master, **kwargs):
+        super().__init__(master, font=get_title_font(), text_color=TEXT, **kwargs)
+
+
+class CardTitle(ctk.CTkLabel):
+    """Titre pour les cartes et sections."""
+
+    def __init__(self, master, **kwargs):
+        super().__init__(master, font=get_section_font(), text_color=TEXT, **kwargs)

--- a/ui/pages/client_detail_page.py
+++ b/ui/pages/client_detail_page.py
@@ -1,8 +1,8 @@
 import customtkinter as ctk
 
 from repositories.client_repo import ClientRepository
-from ui.theme.fonts import get_title_font
-from ui.theme.colors import DARK_BG, TEXT
+from ui.theme.colors import DARK_BG
+from ui.components.design_system import PageTitle, SecondaryButton
 from ui.pages.client_detail_page_components.anamnese_tab import AnamneseTab
 from ui.pages.client_detail_page_components.suivi_tab import SuiviTab
 from ui.pages.client_detail_page_components.stats_tab import StatsTab
@@ -20,27 +20,25 @@ class ClientDetailPage(ctk.CTkFrame):
         repo = ClientRepository()
         client = repo.find_by_id(client_id)
 
-        ctk.CTkButton(
-            self,
+        header = ctk.CTkFrame(self, fg_color="transparent")
+        header.pack(fill="x", padx=20, pady=20)
+
+        SecondaryButton(
+            header,
             text="< Retour",
             command=self.master.master.show_clients_page,
             width=100,
-        ).pack(anchor="w", padx=20, pady=(20, 10))
+        ).pack(side="left")
 
         if client:
             title = f"{client.prenom} {client.nom}"
         else:
             title = "Client introuvable"
 
-        ctk.CTkLabel(
-            self,
-            text=title,
-            font=get_title_font(),
-            text_color=TEXT,
-        ).pack(anchor="w", padx=20, pady=(0, 20))
+        PageTitle(header, text=title).pack(side="left", padx=20)
 
         tabview = ctk.CTkTabview(self)
-        tabview.pack(fill="both", expand=True, padx=20, pady=20)
+        tabview.pack(fill="both", expand=True, padx=20, pady=(0, 20))
         anam_tab = tabview.add("Anamnèse")
         if client:
             AnamneseTab(anam_tab, client).pack(fill="both", expand=True, padx=10, pady=10)

--- a/ui/pages/client_detail_page_components/anamnese_tab.py
+++ b/ui/pages/client_detail_page_components/anamnese_tab.py
@@ -4,6 +4,7 @@ from models.client import Client
 from repositories.client_repo import ClientRepository
 from repositories.exercices_repo import ExerciseRepository
 from ui.components.exclusion_selector import ExclusionSelector
+from ui.components.design_system import Card, CardTitle, PrimaryButton
 
 
 class AnamneseTab(ctk.CTkFrame):
@@ -13,31 +14,35 @@ class AnamneseTab(ctk.CTkFrame):
         self.client_repo = ClientRepository()
         self.exercice_repo = ExerciseRepository()
 
-        info_frame = ctk.CTkFrame(self, fg_color="transparent")
-        info_frame.pack(fill="x", padx=10, pady=10)
+        info_card = Card(self)
+        info_card.pack(fill="x", padx=20, pady=(20, 10))
 
-        ctk.CTkLabel(info_frame, text="Objectifs du client").pack(anchor="w")
-        self.objectifs_txt = ctk.CTkTextbox(info_frame, height=80)
-        self.objectifs_txt.pack(fill="x", pady=(0,10))
+        CardTitle(info_card, text="Informations Clés").pack(anchor="w", padx=20, pady=(20, 10))
+
+        ctk.CTkLabel(info_card, text="Objectifs du client").pack(anchor="w", padx=20)
+        self.objectifs_txt = ctk.CTkTextbox(info_card, height=80)
+        self.objectifs_txt.pack(fill="x", padx=20, pady=(0, 10))
         if client.objectifs:
             self.objectifs_txt.insert("1.0", client.objectifs)
 
-        ctk.CTkLabel(info_frame, text="Antécédents & Notes").pack(anchor="w")
-        self.antecedents_txt = ctk.CTkTextbox(info_frame, height=80)
-        self.antecedents_txt.pack(fill="x")
+        ctk.CTkLabel(info_card, text="Antécédents & Notes").pack(anchor="w", padx=20)
+        self.antecedents_txt = ctk.CTkTextbox(info_card, height=80)
+        self.antecedents_txt.pack(fill="x", padx=20, pady=(0, 20))
         if client.antecedents_medicaux:
             self.antecedents_txt.insert("1.0", client.antecedents_medicaux)
 
-        excl_frame = ctk.CTkFrame(self, fg_color="transparent")
-        excl_frame.pack(fill="both", expand=True, padx=10, pady=10)
+        excl_card = Card(self)
+        excl_card.pack(fill="both", expand=True, padx=20, pady=(0, 20))
+
+        CardTitle(excl_card, text="Exercices à Exclure").pack(anchor="w", padx=20, pady=(20, 10))
 
         all_exercices = self.exercice_repo.list_all_exercices()
         excluded_ids = self.client_repo.get_exclusions(client.id)
 
-        self.selector = ExclusionSelector(excl_frame, all_exercices, excluded_ids)
-        self.selector.pack(fill="both", expand=True)
+        self.selector = ExclusionSelector(excl_card, all_exercices, excluded_ids)
+        self.selector.pack(fill="both", expand=True, padx=20, pady=(0, 20))
 
-        ctk.CTkButton(self, text="Enregistrer les modifications", command=self._save).pack(pady=10)
+        PrimaryButton(self, text="Enregistrer les modifications", command=self._save).pack(anchor="e", padx=20, pady=(0, 20))
 
     def _save(self):
         objectifs = self.objectifs_txt.get("1.0", "end").strip()

--- a/ui/pages/client_detail_page_components/fiche_nutrition_tab.py
+++ b/ui/pages/client_detail_page_components/fiche_nutrition_tab.py
@@ -13,8 +13,9 @@ from services.nutrition_service import (
 )
 from services.pdf_generator import generate_nutrition_sheet_pdf
 from models.fiche_nutrition import FicheNutrition
-from ui.theme.colors import DARK_PANEL, TEXT
-from ui.theme.fonts import get_title_font, get_text_font
+from ui.theme.colors import TEXT
+from ui.theme.fonts import get_text_font
+from ui.components.design_system import Card, CardTitle, PrimaryButton
 
 
 class FicheNutritionTab(ctk.CTkFrame):
@@ -26,17 +27,17 @@ class FicheNutritionTab(ctk.CTkFrame):
         self.client = self.client_repo.find_by_id(client_id)
         self.fiche = self.repo.get_last_for_client(client_id)
 
-        self.display = ctk.CTkFrame(self, fg_color=DARK_PANEL)
-        self.display.pack(fill="both", expand=True, padx=10, pady=10)
+        self.display = Card(self)
+        self.display.pack(fill="both", expand=True, padx=20, pady=20)
 
         btn_frame = ctk.CTkFrame(self, fg_color="transparent")
-        btn_frame.pack(side="bottom", pady=10)
-        ctk.CTkButton(
+        btn_frame.pack(side="bottom", pady=20)
+        PrimaryButton(
             btn_frame,
             text="Générer / Mettre à jour la fiche",
             command=self.open_modal,
         ).pack(side="left", padx=5)
-        self.export_btn = ctk.CTkButton(
+        self.export_btn = PrimaryButton(
             btn_frame,
             text="Exporter en PDF",
             command=self.export_pdf,
@@ -61,15 +62,11 @@ class FicheNutritionTab(ctk.CTkFrame):
             self.export_btn.configure(state="disabled")
         else:
             self.export_btn.configure(state="normal")
-            ctk.CTkLabel(
-                self.display,
-                text="Dernière Fiche Nutritionnelle",
-                font=get_title_font(),
-                text_color=TEXT,
-            ).pack(anchor="w", padx=10, pady=(10, 20))
-
+            CardTitle(self.display, text="Dernière Fiche Nutritionnelle").pack(
+                anchor="w", padx=20, pady=(20, 20)
+            )
             info_frame = ctk.CTkFrame(self.display, fg_color="transparent")
-            info_frame.pack(fill="x", padx=10)
+            info_frame.pack(fill="x", padx=20)
             info_frame.grid_columnconfigure(0, weight=1)
             info_frame.grid_columnconfigure(1, weight=1)
 

--- a/ui/pages/client_detail_page_components/suivi_tab.py
+++ b/ui/pages/client_detail_page_components/suivi_tab.py
@@ -2,6 +2,9 @@ import customtkinter as ctk
 
 from repositories.seance_repo import SeanceRepository
 from ui.modals.session_log_modal import SessionLogModal
+from ui.components.design_system import Card, CardTitle, PrimaryButton
+from ui.theme.colors import TEXT, TEXT_MUTED
+from ui.theme.fonts import get_text_font, get_small_font
 
 
 class SuiviTab(ctk.CTkFrame):
@@ -10,14 +13,14 @@ class SuiviTab(ctk.CTkFrame):
         self.client_id = client_id
         self.repo = SeanceRepository()
 
-        ctk.CTkButton(
+        PrimaryButton(
             self,
             text="Enregistrer une nouvelle séance",
             command=self._open_modal,
-        ).pack(anchor="e", padx=10, pady=10)
+        ).pack(anchor="e", padx=20, pady=20)
 
         self.list_frame = ctk.CTkScrollableFrame(self, fg_color="transparent")
-        self.list_frame.pack(fill="both", expand=True, padx=10, pady=10)
+        self.list_frame.pack(fill="both", expand=True, padx=20, pady=(0, 20))
 
         self._load_seances()
 
@@ -26,10 +29,22 @@ class SuiviTab(ctk.CTkFrame):
             w.destroy()
         seances = self.repo.get_by_client_id(self.client_id)
         for s in seances:
-            item = ctk.CTkFrame(self.list_frame)
-            item.pack(fill="x", pady=5)
-            ctk.CTkLabel(item, text=s.titre).pack(side="left", padx=10)
-            ctk.CTkLabel(item, text=s.date_creation).pack(side="right", padx=10)
+            card = Card(self.list_frame)
+            card.pack(fill="x", pady=10)
+
+            CardTitle(card, text=s.titre).pack(anchor="w", padx=20, pady=(20, 5))
+            ctk.CTkLabel(
+                card,
+                text=s.date_creation,
+                text_color=TEXT_MUTED,
+                font=get_small_font(),
+            ).pack(anchor="w", padx=20)
+            ctk.CTkLabel(
+                card,
+                text=f"Objectif: {s.type_seance}",
+                text_color=TEXT,
+                font=get_text_font(),
+            ).pack(anchor="w", padx=20, pady=(0, 20))
 
     def _open_modal(self):
         SessionLogModal(self, self.client_id, on_saved=self._load_seances)


### PR DESCRIPTION
## Summary
- add `SecondaryButton`, `PageTitle` and `CardTitle` to the design system
- refactor client detail page header to use new components
- redesign Anamnèse, Fiche Nutrition and Suivi tabs with Cards and PrimaryButtons

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689f68473f84832a92922fddbb4007f0