### PR TITLE
feat: automatic database initialization

### DIFF
--- a/db/database_setup.py
+++ b/db/database_setup.py
@@ -1,0 +1,17 @@
+from pathlib import Path
+
+from db.database_manager import db_manager
+from db.seed import create_schema, seed_data
+
+
+def initialize_database() -> None:
+    db_path = Path(db_manager.db_path)
+    if db_path.exists():
+        return
+
+    print("INFO: Base de données non trouvée. Initialisation en cours...")
+    with db_manager._get_connection() as conn:
+        create_schema(conn)
+        seed_data(conn)
+    print("INFO: Base de données initialisée avec succès.")
+

--- a/db/seed.py
+++ b/db/seed.py
@@ -2,91 +2,84 @@ import csv
 from pathlib import Path
 from typing import Optional
 
-from db.database_manager import db_manager
 SCHEMA_PATH = "db/schema.sql"
 CSV_PATH = Path("data/base_aliments_enrichie_bloc4.csv")
 
 
-def recreate_database() -> None:
-    with (
-        db_manager._get_connection() as conn,
-        open(SCHEMA_PATH, "r", encoding="utf-8") as f,
-    ):
+def create_schema(conn) -> None:
+    with open(SCHEMA_PATH, "r", encoding="utf-8") as f:
         conn.executescript(f.read())
 
 
-def seed_exercices_and_clients() -> None:
-    with db_manager._get_connection() as conn:
-        exercices = [
-            ("Squat", "Jambes", "Barre", "Force", 1.0, 1),
-            ("Fente avant", "Jambes", "Haltères", "Hypertrophie", 0.8, 1),
-            ("Développé couché", "Pectoraux", "Barre", "Force", 1.0, 1),
-            ("Tractions", "Dos", "Barre fixe", "Hypertrophie", 1.0, 1),
-            ("Rowing haltère", "Dos", "Haltère", "Hypertrophie", 0.8, 1),
-            ("Planche", "Abdominaux", "Tapis", "Stabilité", 0.5, 0),
-            ("Burpees", "Full body", "Poids du corps", "Cardio", 1.2, 0),
-            ("Saut en hauteur", "Jambes", "Poids du corps", "Pliométrie", 1.0, 0),
-            ("Course à pied", "Jambes", "Tapis", "Endurance", 1.0, 0),
-            ("Développé militaire", "Épaules", "Barre", "Force", 0.9, 1),
-            ("Élévation latérale", "Épaules", "Haltères", "Hypertrophie", 0.3, 1),
-            ("Crunch", "Abdominaux", "Poids du corps", "Hypertrophie", 0.4, 0),
-        ]
-        conn.executemany(
-            """
-            INSERT INTO exercices (
-                nom, groupe_musculaire_principal, equipement,
-                type_effort, coefficient_volume, est_chargeable
-            ) VALUES (?,?,?,?,?,?)
-            """,
-            exercices,
-        )
+def seed_data(conn) -> None:
+    exercices = [
+        ("Squat", "Jambes", "Barre", "Force", 1.0, 1),
+        ("Fente avant", "Jambes", "Haltères", "Hypertrophie", 0.8, 1),
+        ("Développé couché", "Pectoraux", "Barre", "Force", 1.0, 1),
+        ("Tractions", "Dos", "Barre fixe", "Hypertrophie", 1.0, 1),
+        ("Rowing haltère", "Dos", "Haltère", "Hypertrophie", 0.8, 1),
+        ("Planche", "Abdominaux", "Tapis", "Stabilité", 0.5, 0),
+        ("Burpees", "Full body", "Poids du corps", "Cardio", 1.2, 0),
+        ("Saut en hauteur", "Jambes", "Poids du corps", "Pliométrie", 1.0, 0),
+        ("Course à pied", "Jambes", "Tapis", "Endurance", 1.0, 0),
+        ("Développé militaire", "Épaules", "Barre", "Force", 0.9, 1),
+        ("Élévation latérale", "Épaules", "Haltères", "Hypertrophie", 0.3, 1),
+        ("Crunch", "Abdominaux", "Poids du corps", "Hypertrophie", 0.4, 0),
+    ]
+    conn.executemany(
+        """
+        INSERT INTO exercices (
+            nom, groupe_musculaire_principal, equipement,
+            type_effort, coefficient_volume, est_chargeable
+        ) VALUES (?,?,?,?,?,?)
+        """,
+        exercices,
+    )
 
-        clients = [
-            ("Doe", "John", "john@example.com", "1990-01-01"),
-            ("Smith", "Anna", "anna@example.com", "1985-05-12"),
-            ("Martin", "Lucas", "lucas@example.com", "1995-07-23"),
-            ("Durand", "Sophie", "sophie@example.com", "1992-11-05"),
-        ]
-        conn.executemany(
-            "INSERT INTO clients (nom, prenom, email, date_naissance) VALUES (?,?,?,?)",
-            clients,
-        )
+    clients = [
+        ("Doe", "John", "john@example.com", "1990-01-01"),
+        ("Smith", "Anna", "anna@example.com", "1985-05-12"),
+        ("Martin", "Lucas", "lucas@example.com", "1995-07-23"),
+        ("Durand", "Sophie", "sophie@example.com", "1992-11-05"),
+    ]
+    conn.executemany(
+        "INSERT INTO clients (nom, prenom, email, date_naissance) VALUES (?,?,?,?)",
+        clients,
+    )
 
-        seances = [
-            (1, "Individuel", "Séance jambes"),
-            (2, "Individuel", "Séance haut du corps"),
-            (None, "Collectif", "Cours HIIT"),
-            (None, "Collectif", "Yoga matinal"),
-        ]
-        conn.executemany(
-            "INSERT INTO seances (client_id, type_seance, titre) VALUES (?,?,?)",
-            seances,
-        )
+    seances = [
+        (1, "Individuel", "Séance jambes"),
+        (2, "Individuel", "Séance haut du corps"),
+        (None, "Collectif", "Cours HIIT"),
+        (None, "Collectif", "Yoga matinal"),
+    ]
+    conn.executemany(
+        "INSERT INTO seances (client_id, type_seance, titre) VALUES (?,?,?)",
+        seances,
+    )
 
-        def get_exercice_id(nom: str) -> int:
-            cur = conn.execute("SELECT id FROM exercices WHERE nom = ?", (nom,))
-            return cur.fetchone()[0]
+    def get_exercice_id(nom: str) -> int:
+        cur = conn.execute("SELECT id FROM exercices WHERE nom = ?", (nom,))
+        return cur.fetchone()[0]
 
-        resultats = [
-            (1, get_exercice_id("Squat"), 4, 8, 100, "Difficile"),
-            (1, get_exercice_id("Fente avant"), 3, 10, 40, "Brûlant"),
-            (2, get_exercice_id("Développé couché"), 4, 8, 80, "Facile"),
-            (2, get_exercice_id("Tractions"), 3, 6, 0, "Difficile"),
-        ]
-        conn.executemany(
-            """
-            INSERT INTO resultats_exercices (
-                seance_id, exercice_id, series_effectuees,
-                reps_effectuees, charge_utilisee, feedback_client
-            ) VALUES (?,?,?,?,?,?)
-            """,
-            resultats,
-        )
+    resultats = [
+        (1, get_exercice_id("Squat"), 4, 8, 100, "Difficile"),
+        (1, get_exercice_id("Fente avant"), 3, 10, 40, "Brûlant"),
+        (2, get_exercice_id("Développé couché"), 4, 8, 80, "Facile"),
+        (2, get_exercice_id("Tractions"), 3, 6, 0, "Difficile"),
+    ]
+    conn.executemany(
+        """
+        INSERT INTO resultats_exercices (
+            seance_id, exercice_id, series_effectuees,
+            reps_effectuees, charge_utilisee, feedback_client
+        ) VALUES (?,?,?,?,?,?)
+        """,
+        resultats,
+    )
 
-        conn.commit()
+    conn.commit()
 
-
-def seed_aliments_from_csv() -> None:
     if not CSV_PATH.exists():
         print(f"Fichier introuvable: {CSV_PATH}")
         return
@@ -109,10 +102,7 @@ def seed_aliments_from_csv() -> None:
         except Exception:
             return None
 
-    with (
-        db_manager._get_connection() as conn,
-        open(CSV_PATH, newline="", encoding="utf-8") as f,
-    ):
+    with open(CSV_PATH, newline="", encoding="utf-8") as f:
         reader = csv.DictReader(f)
         for row in reader:
             nom = row.get("Aliment", "").strip()
@@ -160,13 +150,14 @@ def seed_aliments_from_csv() -> None:
             except Exception as e:
                 print(f"Erreur lors de l'insertion de {nom}: {e}")
 
-        conn.commit()
+    conn.commit()
 
 
 if __name__ == "__main__":
-    recreate_database()
-    print("Base de données recréée.")
-    seed_exercices_and_clients()
-    print("Données d'exercices et de clients insérées.")
-    seed_aliments_from_csv()
-    print("Données d'aliments migrées.")
+    from db.database_manager import db_manager
+
+    with db_manager._get_connection() as conn:
+        create_schema(conn)
+        print("Base de données recréée.")
+        seed_data(conn)
+        print("Données insérées.")

--- a/main.py
+++ b/main.py
@@ -1,4 +1,6 @@
 from app import launch_app
+from db.database_setup import initialize_database
 
 if __name__ == "__main__":
+    initialize_database()
     launch_app()


### PR DESCRIPTION
### Description
Cette PR rend l'application plus robuste en initialisant automatiquement la base de données au premier lancement.

### Objectifs
- **Simplicité :** L'utilisateur n'a plus besoin de lancer de script manuellement.
- **Fiabilité :** Empêche les crashs de l'application si la base de données est manquante.
- **Maintenance :** La logique de création et de seeding est maintenant séparée et réutilisable.

### Changements
- La logique du script `db/seed.py` a été divisée en fonctions `create_schema` et `seed_data`.
- Un nouveau module `db/database_setup.py` a été créé pour orchestrer l'initialisation.
- `main.py` appelle maintenant `initialize_database()` avant de lancer l'application.

### Comment tester ?
1.  Supprimer le fichier `coach.db` s'il existe.
2.  Lancer l'application avec `python main.py`.
3.  Vérifier que l'application démarre sans erreur et que le fichier `coach.db` a été créé.
4.  Naviguer dans les pages "Séances" ou "Clients" pour confirmer que les données initiales sont


------
https://chatgpt.com/codex/tasks/task_e_68a2040b805c832aa15c6cdd33841023