### PR TITLE
feat: introduce client service layer

### DIFF
--- a/services/client_service.py
+++ b/services/client_service.py
@@ -1,0 +1,41 @@
+from typing import List, Optional
+
+from models.client import Client
+from repositories.client_repo import ClientRepository
+
+
+class ClientService:
+    def __init__(self, repo: ClientRepository) -> None:
+        self.repo = repo
+
+    def get_all_clients(self) -> List[Client]:
+        return self.repo.list_all()
+
+    def get_client_by_id(self, client_id: int) -> Optional[Client]:
+        return self.repo.find_by_id(client_id)
+
+    def add_client(self, client_data: dict) -> None:
+        client = Client(
+            id=None,
+            prenom=client_data["prenom"],
+            nom=client_data["nom"],
+            email=client_data["email"],
+            date_naissance=client_data["date_naissance"],
+        )
+        self.repo.add(client)
+
+    def update_client(self, client: Client, client_data: dict) -> None:
+        client.prenom = client_data["prenom"]
+        client.nom = client_data["nom"]
+        client.email = client_data["email"]
+        client.date_naissance = client_data["date_naissance"]
+        self.repo.update(client)
+
+    def update_client_anamnese(self, client_id: int, objectifs: str, antecedents: str) -> None:
+        self.repo.update_anamnese(client_id, objectifs, antecedents)
+
+    def get_client_exclusions(self, client_id: int) -> List[int]:
+        return self.repo.get_exclusions(client_id)
+
+    def update_client_exclusions(self, client_id: int, exercice_ids: List[int]) -> None:
+        self.repo.update_exclusions(client_id, exercice_ids)

--- a/ui/modals/client_form_modal.py
+++ b/ui/modals/client_form_modal.py
@@ -5,6 +5,7 @@ import customtkinter as ctk
 
 from models.client import Client
 from repositories.client_repo import ClientRepository
+from services.client_service import ClientService
 from ui.theme.colors import DARK_BG, TEXT
 from ui.theme.fonts import get_text_font, get_title_font
 
@@ -15,6 +16,7 @@ class ClientFormModal(ctk.CTkToplevel):
     def __init__(self, parent, client_a_modifier: Optional[Client] = None):
         super().__init__(parent)
         self.client = client_a_modifier
+        self.client_service = ClientService(ClientRepository())
         self.title("Ajouter/Modifier un client")
         self.geometry("400x340")
         self.configure(fg_color=DARK_BG)
@@ -90,22 +92,16 @@ class ClientFormModal(ctk.CTkToplevel):
             messagebox.showerror("Erreur", "Le nom et le prénom sont obligatoires.")
             return
 
-        repo = ClientRepository()
+        client_data = {
+            "prenom": prenom,
+            "nom": nom,
+            "email": email,
+            "date_naissance": date_naissance,
+        }
 
         if self.client:
-            self.client.prenom = prenom
-            self.client.nom = nom
-            self.client.email = email
-            self.client.date_naissance = date_naissance
-            repo.update(self.client)
+            self.client_service.update_client(self.client, client_data)
         else:
-            nouveau_client = Client(
-                id=None,
-                prenom=prenom,
-                nom=nom,
-                email=email,
-                date_naissance=date_naissance,
-            )
-            repo.add(nouveau_client)
+            self.client_service.add_client(client_data)
 
         self.destroy()

--- a/ui/pages/client_detail_page.py
+++ b/ui/pages/client_detail_page.py
@@ -1,6 +1,7 @@
 import customtkinter as ctk
 
 from repositories.client_repo import ClientRepository
+from services.client_service import ClientService
 from ui.components.design_system import PageTitle, SecondaryButton
 from ui.pages.client_detail_page_components.anamnese_tab import AnamneseTab
 from ui.pages.client_detail_page_components.fiche_nutrition_tab import (
@@ -17,8 +18,8 @@ class ClientDetailPage(ctk.CTkFrame):
     def __init__(self, master, client_id: int):
         super().__init__(master, fg_color=DARK_BG)
         self.client_id = client_id
-        repo = ClientRepository()
-        client = repo.find_by_id(client_id)
+        self.client_service = ClientService(ClientRepository())
+        client = self.client_service.get_client_by_id(client_id)
 
         header = ctk.CTkFrame(self, fg_color="transparent")
         header.pack(fill="x", padx=20, pady=20)

--- a/ui/pages/client_detail_page_components/anamnese_tab.py
+++ b/ui/pages/client_detail_page_components/anamnese_tab.py
@@ -3,6 +3,7 @@ import customtkinter as ctk
 from models.client import Client
 from repositories.client_repo import ClientRepository
 from repositories.exercices_repo import ExerciseRepository
+from services.client_service import ClientService
 from ui.components.design_system import Card, CardTitle, PrimaryButton
 from ui.components.exclusion_selector import ExclusionSelector
 
@@ -11,7 +12,7 @@ class AnamneseTab(ctk.CTkFrame):
     def __init__(self, master, client: Client):
         super().__init__(master, fg_color="transparent")
         self.client = client
-        self.client_repo = ClientRepository()
+        self.client_service = ClientService(ClientRepository())
         self.exercice_repo = ExerciseRepository()
 
         info_card = Card(self)
@@ -41,7 +42,7 @@ class AnamneseTab(ctk.CTkFrame):
         )
 
         all_exercices = self.exercice_repo.list_all_exercices()
-        excluded_ids = self.client_repo.get_exclusions(client.id)
+        excluded_ids = self.client_service.get_client_exclusions(client.id)
 
         self.selector = ExclusionSelector(excl_card, all_exercices, excluded_ids)
         self.selector.pack(fill="both", expand=True, padx=20, pady=(0, 20))
@@ -54,5 +55,7 @@ class AnamneseTab(ctk.CTkFrame):
         objectifs = self.objectifs_txt.get("1.0", "end").strip()
         antecedents = self.antecedents_txt.get("1.0", "end").strip()
         excluded_ids = self.selector.get_excluded_ids()
-        self.client_repo.update_anamnese(self.client.id, objectifs, antecedents)
-        self.client_repo.update_exclusions(self.client.id, excluded_ids)
+        self.client_service.update_client_anamnese(
+            self.client.id, objectifs, antecedents
+        )
+        self.client_service.update_client_exclusions(self.client.id, excluded_ids)

--- a/ui/pages/clients_page.py
+++ b/ui/pages/clients_page.py
@@ -2,6 +2,7 @@ import customtkinter as ctk
 
 from models.client import Client
 from repositories.client_repo import ClientRepository
+from services.client_service import ClientService
 from ui.modals.client_form_modal import ClientFormModal
 from ui.theme.colors import DARK_BG, DARK_PANEL, TEXT, TEXT_SECONDARY
 from ui.theme.fonts import get_small_font, get_text_font, get_title_font
@@ -14,7 +15,7 @@ class ClientsPage(ctk.CTkFrame):
         super().__init__(parent)
         self.configure(fg_color=DARK_BG)
 
-        self.repo = ClientRepository()
+        self.client_service = ClientService(ClientRepository())
 
         ctk.CTkLabel(
             self,
@@ -44,7 +45,7 @@ class ClientsPage(ctk.CTkFrame):
         for widget in self.scroll.winfo_children():
             widget.destroy()
 
-        clients = self.repo.list_all()
+        clients = self.client_service.get_all_clients()
         for client in clients:
             self._create_client_card(client)
 

--- a/ui/pages/session_page_components/form_individuel.py
+++ b/ui/pages/session_page_components/form_individuel.py
@@ -1,6 +1,7 @@
 import customtkinter as ctk
 
 from repositories.client_repo import ClientRepository
+from services.client_service import ClientService
 
 OBJECTIFS = ["Volume", "Force", "Endurance", "Technique"]
 
@@ -26,8 +27,8 @@ class FormIndividuel(ctk.CTkFrame):
         ctk.CTkLabel(row1, text="Sélectionner un client").grid(
             row=0, column=0, sticky="w", padx=(0, 8)
         )
-        repo = ClientRepository()
-        clients = repo.list_all()
+        self.client_service = ClientService(ClientRepository())
+        clients = self.client_service.get_all_clients()
         client_names = [f"{c.prenom} {c.nom}" for c in clients]
         self.client_var = ctk.StringVar(value=client_names[0] if client_names else "")
         ctk.CTkOptionMenu(row1, variable=self.client_var, values=client_names).grid(


### PR DESCRIPTION
### Description
Cette PR introduit la couche "Service", un élément central de notre architecture cible, en commençant par la gestion des clients.

### Objectifs
- **Séparation des préoccupations (SoC) :** Isoler la logique métier de l'interface utilisateur. La couche UI ne fait plus que de l'affichage et de la capture d'événements.
- **Testabilité :** Rendre la logique métier plus facile à tester de manière unitaire, indépendamment de l'UI.
- **Maintenabilité :** Centraliser les règles de gestion des clients en un seul endroit.

### Changements
- Création d'un `ClientService` qui orchestre les opérations sur les clients.
- Mise à jour des pages `ClientsPage`, `ClientDetailPage`, de la modale `ClientFormModal`, de l'onglet `AnamneseTab` et du formulaire `FormIndividuel` pour utiliser ce nouveau service au lieu du repository directement.

### Comment tester ?
1. Lancer l'application.
2. Aller sur la page "Clients".
3. Vérifier que la liste des clients s'affiche correctement.
4. Ajouter un nouveau client via la modale.
5. Modifier un client existant.
6. Cliquer sur un client pour voir sa page de détail et vérifier que les informations s'affichent correctement.
7. Mettre à jour l'anamnèse et les exclusions d'exercices et vérifier qu'elles sont sauvegardées.
8. Ouvrir le formulaire de séance individuelle et confirmer que la liste déroulante des clients est correctement remplie.


------
https://chatgpt.com/codex/tasks/task_e_68a21d73f140832ab1a0ce0042236b7a