### PR TITLE
fix/pdf-generator-colors

### DIFF
--- a/services/pdf_generator.py
+++ b/services/pdf_generator.py
@@ -6,7 +6,22 @@ from reportlab.lib.utils import ImageReader
 from reportlab.pdfgen import canvas
 
 from models.client import Client
-from ui.theme.colors import DARK_BG, DARK_PANEL, PRIMARY, SECONDARY, TEXT, TEXT_MUTED
+from ui.theme.colors import (
+    NEUTRAL_100,
+    NEUTRAL_300,
+    NEUTRAL_700,
+    NEUTRAL_800,
+    NEUTRAL_900,
+    PRIMARY,
+)
+
+# Mapping des anciennes couleurs vers le nouveau Design System
+DARK_BG = NEUTRAL_900
+DARK_PANEL = NEUTRAL_800
+TEXT = NEUTRAL_100
+TEXT_MUTED = NEUTRAL_300
+# On choisit une couleur neutre pour remplacer l'ancienne 'SECONDARY'
+SECONDARY = NEUTRAL_700
 
 
 def generate_nutrition_sheet_pdf(


### PR DESCRIPTION
### Description
Cette PR corrige un crash au démarrage causé par une `ImportError` dans le `pdf_generator.py`.

### Cause du bug
Le module de génération de PDF utilisait une ancienne palette de couleurs (notamment la couleur `SECONDARY`) qui a été supprimée lors de la mise en place du Design System.

### Solution
- Mise à jour des imports dans `pdf_generator.py` pour utiliser les nouvelles variables de couleurs standardisées.
- Ajout d'un mapping pour assurer la compatibilité avec le reste du code de la fonction et corriger le bug.

### Comment tester ?
1.  Lancer l'application. Elle doit démarrer sans erreur.
2.  Aller sur la fiche d'un client, générer une fiche nutrition, puis l'exporter en PDF.
3.  Vérifier que le PDF est généré correctement.


------
https://chatgpt.com/codex/tasks/task_e_68a2dfb68c48832a88bebc412ac64789