### PR TITLE
fix: load seed data from CSV with absolute paths

### DIFF
--- a/db/seed.py
+++ b/db/seed.py
@@ -1,11 +1,15 @@
 import csv
-from pathlib import Path
+import os
 from typing import Optional
 
 from db.database_manager import db_manager
 
-SCHEMA_PATH = "db/schema.sql"
-CSV_PATH = Path("data/base_aliments_enrichie_bloc4.csv")
+BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+SCHEMA_PATH = os.path.join(BASE_DIR, "db", "schema.sql")
+EXERCISES_CSV = os.path.join(BASE_DIR, "data", "exercices_master.csv")
+ALIMENTS_CSV = os.path.join(
+    BASE_DIR, "data", "base_aliments_enrichie_bloc4.csv"
+)
 
 
 def create_schema():
@@ -16,26 +20,44 @@ def create_schema():
 
 def seed_data():
     with db_manager.get_connection() as conn:
-        exercices = [
-            ("Squat", "Jambes", "Barre", "Force", 1.0, 1),
-            ("Fente avant", "Jambes", "Haltères", "Hypertrophie", 0.8, 1),
-            ("Développé couché", "Pectoraux", "Barre", "Force", 1.0, 1),
-            ("Tractions", "Dos", "Barre fixe", "Hypertrophie", 1.0, 1),
-            ("Rowing haltère", "Dos", "Haltère", "Hypertrophie", 0.8, 1),
-            ("Planche", "Abdominaux", "Tapis", "Stabilité", 0.5, 0),
-            ("Burpees", "Full body", "Poids du corps", "Cardio", 1.2, 0),
-            ("Saut en hauteur", "Jambes", "Poids du corps", "Pliométrie", 1.0, 0),
-            ("Course à pied", "Jambes", "Tapis", "Endurance", 1.0, 0),
-            ("Développé militaire", "Épaules", "Barre", "Force", 0.9, 1),
-            ("Élévation latérale", "Épaules", "Haltères", "Hypertrophie", 0.3, 1),
-            ("Crunch", "Abdominaux", "Poids du corps", "Hypertrophie", 0.4, 0),
-        ]
+        # Chargement des exercices depuis le CSV
+        with open(EXERCISES_CSV, newline="", encoding="utf-8") as f:
+            reader = csv.DictReader(f)
+            exercices = []
+            for row in reader:
+                nom = row.get("name", "").strip()
+                if not nom:
+                    continue
+                groupe = row.get("primary_muscle", "").strip()
+                equip_list = [
+                    e.strip() for e in row.get("equipment", "").split(";") if e.strip()
+                ]
+                equipement = ", ".join(equip_list)
+                tags = ", ".join(
+                    e.strip() for e in row.get("tags", "").split(";") if e.strip()
+                )
+                movement_pattern = row.get("movement_pattern", "").strip() or None
+                type_effort = row.get("category", "").strip() or ""
+                est_chargeable = 0 if equip_list and equip_list == ["Poids du corps"] else 1
+                exercices.append(
+                    (
+                        nom,
+                        groupe,
+                        equipement,
+                        tags or None,
+                        movement_pattern,
+                        type_effort,
+                        1.0,
+                        est_chargeable,
+                    )
+                )
+
         conn.executemany(
             """
             INSERT INTO exercices (
-                nom, groupe_musculaire_principal, equipement,
+                nom, groupe_musculaire_principal, equipement, tags, movement_pattern,
                 type_effort, coefficient_volume, est_chargeable
-            ) VALUES (?,?,?,?,?,?)
+            ) VALUES (?,?,?,?,?,?,?,?)
             """,
             exercices,
         )
@@ -62,31 +84,28 @@ def seed_data():
             seances,
         )
 
-        def get_exercice_id(nom: str) -> int:
+        def get_exercice_id(nom: str) -> Optional[int]:
             cur = conn.execute("SELECT id FROM exercices WHERE nom = ?", (nom,))
-            return cur.fetchone()[0]
+            row = cur.fetchone()
+            return row[0] if row else None
 
         resultats = [
-            (1, get_exercice_id("Squat"), 4, 8, 100, "Difficile"),
-            (1, get_exercice_id("Fente avant"), 3, 10, 40, "Brûlant"),
-            (2, get_exercice_id("Développé couché"), 4, 8, 80, "Facile"),
-            (2, get_exercice_id("Tractions"), 3, 6, 0, "Difficile"),
+            (1, get_exercice_id("Air squat"), 4, 8, 0, "Difficile"),
+            (1, get_exercice_id("Goblet squat"), 3, 10, 20, "Brûlant"),
+            (2, get_exercice_id("Barbell bench press"), 4, 8, 80, "Facile"),
+            (2, get_exercice_id("Pull-up"), 3, 6, 0, "Difficile"),
         ]
-        conn.executemany(
-            """
-            INSERT INTO resultats_exercices (
-                seance_id, exercice_id, series_effectuees,
-                reps_effectuees, charge_utilisee, feedback_client
-            ) VALUES (?,?,?,?,?,?)
-            """,
-            resultats,
-        )
-
-        conn.commit()
-
-        if not CSV_PATH.exists():
-            print(f"Fichier introuvable: {CSV_PATH}")
-            return
+        resultats = [r for r in resultats if r[1] is not None]
+        if resultats:
+            conn.executemany(
+                """
+                INSERT INTO resultats_exercices (
+                    seance_id, exercice_id, series_effectuees,
+                    reps_effectuees, charge_utilisee, feedback_client
+                ) VALUES (?,?,?,?,?,?)
+                """,
+                resultats,
+            )
 
         def parse_float(value: str) -> Optional[float]:
             try:
@@ -105,54 +124,58 @@ def seed_data():
                 return int(value)
             except Exception:
                 return None
-
-        with open(CSV_PATH, newline="", encoding="utf-8") as f:
-            reader = csv.DictReader(f)
-            for row in reader:
-                nom = row.get("Aliment", "").strip()
-                if not nom:
-                    continue
-
-                categorie = row.get("Catégorie", "").strip() or None
-                kcal = parse_float(row.get("Kcal", "")) or 0.0
-                prot = parse_float(row.get("Protéines (g)", "")) or 0.0
-                gluc = parse_float(row.get("Glucides (g)", "")) or 0.0
-                lip = parse_float(row.get("Lipides (g)", "")) or 0.0
-                ind_healthy = parse_int(row.get("Healthy (Indice)", ""))
-                ind_commun = parse_int(row.get("Commun (Indice)", ""))
-
-                try:
-                    cur = conn.execute(
-                        (
-                            "INSERT OR IGNORE INTO aliments "
-                            "(nom, categorie, type_alimentation, kcal_100g, proteines_100g, "
-                            "glucides_100g, lipides_100g, fibres_100g, unite_base, indice_healthy, indice_commun) "
-                            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, 'g', ?, ?)"
-                        ),
-                        (
-                            nom,
-                            categorie,
-                            None,
-                            kcal,
-                            prot,
-                            gluc,
-                            lip,
-                            None,
-                            ind_healthy,
-                            ind_commun,
-                        ),
-                    )
-
-                    if cur.rowcount == 0:
+        try:
+            with open(ALIMENTS_CSV, newline="", encoding="utf-8") as f:
+                reader = csv.DictReader(f)
+                for row in reader:
+                    nom = row.get("Aliment", "").strip()
+                    if not nom:
                         continue
 
-                    aliment_id = cur.lastrowid
-                    conn.execute(
-                        "INSERT INTO portions (aliment_id, description, grammes_equivalents) VALUES (?, ?, ?)",
-                        (aliment_id, "100g", 100),
-                    )
-                except Exception as e:
-                    print(f"Erreur lors de l'insertion de {nom}: {e}")
+                    categorie = row.get("Catégorie", "").strip() or None
+                    kcal = parse_float(row.get("Kcal", "")) or 0.0
+                    prot = parse_float(row.get("Protéines (g)", "")) or 0.0
+                    gluc = parse_float(row.get("Glucides (g)", "")) or 0.0
+                    lip = parse_float(row.get("Lipides (g)", "")) or 0.0
+                    ind_healthy = parse_int(row.get("Healthy (Indice)", ""))
+                    ind_commun = parse_int(row.get("Commun (Indice)", ""))
+
+                    try:
+                        cur = conn.execute(
+                            (
+                                "INSERT OR IGNORE INTO aliments "
+                                "(nom, categorie, type_alimentation, kcal_100g, proteines_100g, "
+                                "glucides_100g, lipides_100g, fibres_100g, unite_base, indice_healthy, indice_commun) "
+                                "VALUES (?, ?, ?, ?, ?, ?, ?, ?, 'g', ?, ?)"
+                            ),
+                            (
+                                nom,
+                                categorie,
+                                None,
+                                kcal,
+                                prot,
+                                gluc,
+                                lip,
+                                None,
+                                ind_healthy,
+                                ind_commun,
+                            ),
+                        )
+
+                        if cur.rowcount == 0:
+                            continue
+
+                        aliment_id = cur.lastrowid
+                        conn.execute(
+                            "INSERT INTO portions (aliment_id, description, grammes_equivalents) VALUES (?, ?, ?)",
+                            (aliment_id, "100g", 100),
+                        )
+                    except Exception as e:
+                        print(f"Erreur lors de l'insertion de {nom}: {e}")
+        except FileNotFoundError:
+            print(
+                "INFO: Fichier de base des aliments non trouvé. Le seeding continuera sans."
+            )
 
         conn.commit()
 


### PR DESCRIPTION
## Summary
- build absolute paths for schema and data files in seed script
- load exercises from `data/exercices_master.csv` instead of hardcoded list
- gracefully handle optional missing food data file

## Testing
- `python - <<'PY'
from db.database_setup import initialize_database
initialize_database()
print('init done')
PY`
- `python - <<'PY'
import random
from repositories.exercices_repo import ExerciseRepository
from services.session_generator import filter_pool, weighted_choice
repo = ExerciseRepository()
pool = filter_pool(repo, {'course_type':'CAF','equipment':['Poids du corps']})
print('pool size', len(pool))
weighted_choice(random.Random(), pool, 0.5)
print('generator ok')
PY`
- `pytest -q` *(fails: no display name and no $DISPLAY environment variable)*

------
https://chatgpt.com/codex/tasks/task_e_68a2e9a45b94832aad2ebb7f1f311735