### PR TITLE
Add guard clause for empty exercise pool in session generator

### DIFF
--- a/services/session_generator.py
+++ b/services/session_generator.py
@@ -154,6 +154,10 @@ def generate_collectif(params: Dict[str, Any]) -> Session:
     tpl = T.pick_template(params["course_type"], params["duration_min"])
     repo = ExerciseRepository()
     pool = filter_pool(repo, params)
+    if not pool:
+        raise ValueError(
+            "Impossible de générer une séance : la base de données d'exercices est vide."
+        )
     rng = random.Random(params.get("seed") or int(time.time()))
     entropy = map_slider_to_entropy(params.get("variability", 50))
 


### PR DESCRIPTION
## Summary
- raise ValueError when exercise pool is empty in `generate_collectif`

## Testing
- `python -m pytest` *(fails: no display name and no $DISPLAY environment variable)*

------
https://chatgpt.com/codex/tasks/task_e_68a2ededf1f4832aba6c764da6020606