### PR TITLE
Refactorise le module Client en architecture MVC+Services

### DIFF
--- a/app.py
+++ b/app.py
@@ -17,6 +17,10 @@ from ui.pages.program_page import ProgramPage
 from ui.pages.progress_page import ProgressPage
 from ui.pages.session_page import SessionPage
 
+from controllers.client_controller import ClientController
+from repositories.client_repo import ClientRepository
+from services.client_service import ClientService
+
 
 class CoachApp(ctk.CTk):
     def __init__(self):
@@ -39,6 +43,11 @@ class CoachApp(ctk.CTk):
         self.current_page = None
         self.clients_page = None
         self.client_detail_page = None
+
+        repo = ClientRepository()
+        service = ClientService(repo)
+        self.client_controller = ClientController(service)
+
         self.switch_page("dashboard")  # Page par défaut
 
     def switch_page(self, page_name):
@@ -68,7 +77,7 @@ class CoachApp(ctk.CTk):
             case "pdf":
                 self.current_page = PdfPage(self.main_frame)
             case "clients":
-                self.clients_page = ClientsPage(self.main_frame)
+                self.clients_page = ClientsPage(self.main_frame, self.client_controller)
                 self.current_page = self.clients_page
             case "messaging":
                 self.current_page = MessagingPage(self.main_frame)
@@ -83,7 +92,9 @@ class CoachApp(ctk.CTk):
         """Affiche la page de détail d'un client."""
         if self.clients_page:
             self.clients_page.pack_forget()
-        self.client_detail_page = ClientDetailPage(self.main_frame, client_id)
+        self.client_detail_page = ClientDetailPage(
+            self.main_frame, self.client_controller, client_id
+        )
         self.client_detail_page.pack(fill="both", expand=True)
         self.current_page = self.client_detail_page
 

--- a/controllers/client_controller.py
+++ b/controllers/client_controller.py
@@ -1,0 +1,40 @@
+from typing import List, Optional
+
+from models.client import Client
+from services.client_service import ClientService
+
+
+class ClientController:
+    """Controller providing CRUD operations for clients."""
+
+    def __init__(self, service: ClientService) -> None:
+        self.service = service
+
+    def get_all_clients_for_view(self) -> List[Client]:
+        return self.service.get_all_clients()
+
+    def get_client_by_id(self, client_id: int) -> Optional[Client]:
+        return self.service.get_client_by_id(client_id)
+
+    def add_client(self, data: dict) -> None:
+        self.service.add_client(data)
+
+    def update_client(self, client_id: int, data: dict) -> None:
+        client = self.service.get_client_by_id(client_id)
+        if not client:
+            raise ValueError("Client introuvable")
+        self.service.update_client(client, data)
+
+    def delete_client(self, client_id: int) -> None:
+        self.service.delete_client(client_id)
+
+    def update_client_anamnese(
+        self, client_id: int, objectifs: str, antecedents: str
+    ) -> None:
+        self.service.update_client_anamnese(client_id, objectifs, antecedents)
+
+    def get_client_exclusions(self, client_id: int) -> List[int]:
+        return self.service.get_client_exclusions(client_id)
+
+    def update_client_exclusions(self, client_id: int, exercice_ids: List[int]) -> None:
+        self.service.update_client_exclusions(client_id, exercice_ids)

--- a/repositories/client_repo.py
+++ b/repositories/client_repo.py
@@ -82,6 +82,12 @@ class ClientRepository:
             )
             conn.commit()
 
+    def delete(self, client_id: int) -> None:
+        with db_manager.get_connection() as conn:
+            cursor = conn.cursor()
+            cursor.execute("DELETE FROM clients WHERE id = ?", (client_id,))
+            conn.commit()
+
     def update_anamnese(self, client_id: int, objectifs: str, antecedents: str) -> None:
         with db_manager.get_connection() as conn:
             cursor = conn.cursor()

--- a/services/client_service.py
+++ b/services/client_service.py
@@ -1,3 +1,4 @@
+import re
 from typing import List, Optional
 
 from models.client import Client
@@ -14,22 +15,34 @@ class ClientService:
     def get_client_by_id(self, client_id: int) -> Optional[Client]:
         return self.repo.find_by_id(client_id)
 
+    def validate_client_data(self, data: dict) -> None:
+        if not data.get("prenom") or not data.get("nom"):
+            raise ValueError("Le nom et le prénom sont obligatoires.")
+        email = data.get("email")
+        if email and not re.match(r"^[^@\s]+@[^@\s]+\.[^@\s]+$", email):
+            raise ValueError("L'email est invalide.")
+
     def add_client(self, client_data: dict) -> None:
+        self.validate_client_data(client_data)
         client = Client(
             id=None,
             prenom=client_data["prenom"],
             nom=client_data["nom"],
-            email=client_data["email"],
-            date_naissance=client_data["date_naissance"],
+            email=client_data.get("email"),
+            date_naissance=client_data.get("date_naissance"),
         )
         self.repo.add(client)
 
     def update_client(self, client: Client, client_data: dict) -> None:
+        self.validate_client_data(client_data)
         client.prenom = client_data["prenom"]
         client.nom = client_data["nom"]
-        client.email = client_data["email"]
-        client.date_naissance = client_data["date_naissance"]
+        client.email = client_data.get("email")
+        client.date_naissance = client_data.get("date_naissance")
         self.repo.update(client)
+
+    def delete_client(self, client_id: int) -> None:
+        self.repo.delete(client_id)
 
     def update_client_anamnese(
         self, client_id: int, objectifs: str, antecedents: str

--- a/ui/modals/client_form_modal.py
+++ b/ui/modals/client_form_modal.py
@@ -4,8 +4,7 @@ from typing import Optional
 import customtkinter as ctk
 
 from models.client import Client
-from repositories.client_repo import ClientRepository
-from services.client_service import ClientService
+from controllers.client_controller import ClientController
 from ui.theme.colors import DARK_BG, TEXT
 from ui.theme.fonts import get_text_font, get_title_font
 
@@ -13,10 +12,15 @@ from ui.theme.fonts import get_text_font, get_title_font
 class ClientFormModal(ctk.CTkToplevel):
     """Fenêtre modale pour ajouter ou modifier un client."""
 
-    def __init__(self, parent, client_a_modifier: Optional[Client] = None):
+    def __init__(
+        self,
+        parent,
+        controller: ClientController,
+        client_a_modifier: Optional[Client] = None,
+    ):
         super().__init__(parent)
         self.client = client_a_modifier
-        self.client_service = ClientService(ClientRepository())
+        self.controller = controller
         self.title("Ajouter/Modifier un client")
         self.geometry("400x340")
         self.configure(fg_color=DARK_BG)
@@ -88,10 +92,6 @@ class ClientFormModal(ctk.CTkToplevel):
         email = self.email_var.get().strip() or None
         date_naissance = self.date_var.get().strip() or None
 
-        if not prenom or not nom:
-            messagebox.showerror("Erreur", "Le nom et le prénom sont obligatoires.")
-            return
-
         client_data = {
             "prenom": prenom,
             "nom": nom,
@@ -99,9 +99,11 @@ class ClientFormModal(ctk.CTkToplevel):
             "date_naissance": date_naissance,
         }
 
-        if self.client:
-            self.client_service.update_client(self.client, client_data)
-        else:
-            self.client_service.add_client(client_data)
-
-        self.destroy()
+        try:
+            if self.client:
+                self.controller.update_client(self.client.id, client_data)
+            else:
+                self.controller.add_client(client_data)
+            self.destroy()
+        except ValueError as e:
+            messagebox.showerror("Erreur", str(e))

--- a/ui/pages/client_detail_page.py
+++ b/ui/pages/client_detail_page.py
@@ -1,7 +1,6 @@
 import customtkinter as ctk
 
-from repositories.client_repo import ClientRepository
-from services.client_service import ClientService
+from controllers.client_controller import ClientController
 from ui.components.design_system import PageTitle, SecondaryButton
 from ui.pages.client_detail_page_components.anamnese_tab import AnamneseTab
 from ui.pages.client_detail_page_components.fiche_nutrition_tab import (
@@ -15,11 +14,11 @@ from ui.theme.colors import NEUTRAL_900
 class ClientDetailPage(ctk.CTkFrame):
     """Page affichant les détails d'un client."""
 
-    def __init__(self, master, client_id: int):
+    def __init__(self, master, controller: ClientController, client_id: int):
         super().__init__(master, fg_color=NEUTRAL_900)
         self.client_id = client_id
-        self.client_service = ClientService(ClientRepository())
-        client = self.client_service.get_client_by_id(client_id)
+        self.controller = controller
+        client = self.controller.get_client_by_id(client_id)
 
         header = ctk.CTkFrame(self, fg_color="transparent")
         header.pack(fill="x", padx=20, pady=20)
@@ -42,7 +41,7 @@ class ClientDetailPage(ctk.CTkFrame):
         tabview.pack(fill="both", expand=True, padx=20, pady=(0, 20))
         anam_tab = tabview.add("Anamnèse")
         if client:
-            AnamneseTab(anam_tab, client).pack(
+            AnamneseTab(anam_tab, self.controller, client).pack(
                 fill="both", expand=True, padx=10, pady=10
             )
         suivi_tab = tabview.add("Suivi & Séances")
@@ -54,6 +53,6 @@ class ClientDetailPage(ctk.CTkFrame):
             fill="both", expand=True, padx=10, pady=10
         )
         fiche_tab = tabview.add("Fiche Nutrition")
-        FicheNutritionTab(fiche_tab, self.client_id).pack(
+        FicheNutritionTab(fiche_tab, self.controller, self.client_id).pack(
             fill="both", expand=True, padx=10, pady=10
         )

--- a/ui/pages/client_detail_page_components/anamnese_tab.py
+++ b/ui/pages/client_detail_page_components/anamnese_tab.py
@@ -1,18 +1,17 @@
 import customtkinter as ctk
 
 from models.client import Client
-from repositories.client_repo import ClientRepository
 from repositories.exercices_repo import ExerciseRepository
-from services.client_service import ClientService
+from controllers.client_controller import ClientController
 from ui.components.design_system import Card, CardTitle, PrimaryButton
 from ui.components.exclusion_selector import ExclusionSelector
 
 
 class AnamneseTab(ctk.CTkFrame):
-    def __init__(self, master, client: Client):
+    def __init__(self, master, controller: ClientController, client: Client):
         super().__init__(master, fg_color="transparent")
         self.client = client
-        self.client_service = ClientService(ClientRepository())
+        self.controller = controller
         self.exercice_repo = ExerciseRepository()
 
         info_card = Card(self)
@@ -42,7 +41,7 @@ class AnamneseTab(ctk.CTkFrame):
         )
 
         all_exercices = self.exercice_repo.list_all_exercices()
-        excluded_ids = self.client_service.get_client_exclusions(client.id)
+        excluded_ids = self.controller.get_client_exclusions(client.id)
 
         self.selector = ExclusionSelector(excl_card, all_exercices, excluded_ids)
         self.selector.pack(fill="both", expand=True, padx=20, pady=(0, 20))
@@ -55,7 +54,7 @@ class AnamneseTab(ctk.CTkFrame):
         objectifs = self.objectifs_txt.get("1.0", "end").strip()
         antecedents = self.antecedents_txt.get("1.0", "end").strip()
         excluded_ids = self.selector.get_excluded_ids()
-        self.client_service.update_client_anamnese(
+        self.controller.update_client_anamnese(
             self.client.id, objectifs, antecedents
         )
-        self.client_service.update_client_exclusions(self.client.id, excluded_ids)
+        self.controller.update_client_exclusions(self.client.id, excluded_ids)

--- a/ui/pages/client_detail_page_components/fiche_nutrition_tab.py
+++ b/ui/pages/client_detail_page_components/fiche_nutrition_tab.py
@@ -4,25 +4,25 @@ from tkinter import filedialog
 
 import customtkinter as ctk
 
-from repositories.client_repo import ClientRepository
 from repositories.fiche_nutrition_repo import FicheNutritionRepository
 from services.nutrition_service import (
     ACTIVITY_FACTORS,
     OBJECTIVE_ADJUST,
     NutritionService,
 )
+from controllers.client_controller import ClientController
 from ui.components.design_system import Card, CardTitle, PrimaryButton
 from ui.theme.colors import TEXT
 from ui.theme.fonts import get_text_font
 
 
 class FicheNutritionTab(ctk.CTkFrame):
-    def __init__(self, master, client_id: int):
+    def __init__(self, master, controller: ClientController, client_id: int):
         super().__init__(master, fg_color="transparent")
         self.client_id = client_id
+        self.controller = controller
         self.nutrition_service = NutritionService(FicheNutritionRepository())
-        self.client_repo = ClientRepository()
-        self.client = self.client_repo.find_by_id(client_id)
+        self.client = self.controller.get_client_by_id(client_id)
         self.fiche = self.nutrition_service.get_last_sheet_for_client(client_id)
 
         self.display = Card(self)

--- a/ui/pages/clients_page.py
+++ b/ui/pages/clients_page.py
@@ -1,8 +1,7 @@
 import customtkinter as ctk
 
 from models.client import Client
-from repositories.client_repo import ClientRepository
-from services.client_service import ClientService
+from controllers.client_controller import ClientController
 from ui.components.design_system import (
     Card,
     CardTitle,
@@ -18,11 +17,11 @@ from ui.theme.fonts import LABEL_NORMAL
 class ClientsPage(ctk.CTkFrame):
     """Page de gestion des clients."""
 
-    def __init__(self, parent):
+    def __init__(self, parent, controller: ClientController):
         super().__init__(parent)
         self.configure(fg_color=NEUTRAL_900)
 
-        self.client_service = ClientService(ClientRepository())
+        self.controller = controller
 
         PageTitle(self, text="Gestion des Clients").pack(
             anchor="w", padx=20, pady=(20, 24)
@@ -49,7 +48,7 @@ class ClientsPage(ctk.CTkFrame):
         for widget in self.scroll.winfo_children():
             widget.destroy()
 
-        clients = self.client_service.get_all_clients()
+        clients = self.controller.get_all_clients_for_view()
         for client in clients:
             self._create_client_card(client)
 
@@ -88,13 +87,13 @@ class ClientsPage(ctk.CTkFrame):
 
     # -- Modal handlers ---------------------------------------------------
     def _open_add_modal(self) -> None:
-        modal = ClientFormModal(self)
+        modal = ClientFormModal(self, self.controller)
         modal.grab_set()
         self.wait_window(modal)
         self._load_clients()
 
     def _open_edit_modal(self, client: Client) -> None:
-        modal = ClientFormModal(self, client)
+        modal = ClientFormModal(self, self.controller, client)
         modal.grab_set()
         self.wait_window(modal)
         self._load_clients()


### PR DESCRIPTION
## Résumé
- Ajout du `ClientController` pour centraliser les opérations CRUD
- Déplacement de la logique métier et des validations dans `ClientService`
- Découplage de l'interface des dépôts via injection du contrôleur

## Testing
- `pytest` *(échoue : no display name and no $DISPLAY environment variable)*

------
https://chatgpt.com/codex/tasks/task_e_68a7110403e0832aba0d40385fea53aa