### PR TITLE
feat: UI shell layout with sidebar and header

### DIFF
--- a/ui/layout/app_shell.py
+++ b/ui/layout/app_shell.py
@@ -1,0 +1,32 @@
+import customtkinter as ctk
+
+from ui.layout.header import Header
+from ui.layout.sidebar import Sidebar
+from ui.theme import colors
+
+
+class AppShell(ctk.CTkFrame):
+    """Main application shell with persistent sidebar and header."""
+
+    def __init__(self, parent, switch_page_callback, active_module: str = "dashboard"):
+        super().__init__(parent)
+        self.grid_rowconfigure(1, weight=1)
+        self.grid_columnconfigure(1, weight=1)
+
+        # Sidebar
+        self.sidebar = Sidebar(self, switch_page_callback, active_module=active_module)
+        self.sidebar.grid(row=0, column=0, rowspan=2, sticky="nsw")
+
+        # Header
+        self.header = Header(self)
+        self.header.grid(row=0, column=1, sticky="ew")
+
+        # Content area
+        self.content_area = ctk.CTkFrame(self, fg_color=colors.NEUTRAL_900)
+        self.content_area.grid(row=1, column=1, sticky="nsew")
+
+    def set_content(self, widget: ctk.CTkFrame) -> None:
+        """Replace the current content area with a new widget."""
+        for child in self.content_area.winfo_children():
+            child.destroy()
+        widget.pack(fill="both", expand=True)

--- a/ui/layout/header.py
+++ b/ui/layout/header.py
@@ -1,35 +1,36 @@
 # ui/layout/header.py
 
-import os
-
 import customtkinter as ctk
-from PIL import Image
+
+from utils.icon_loader import load_icon
+from ui.theme import colors, fonts
 
 
 class Header(ctk.CTkFrame):
-    def __init__(self, parent, title="CoachPro"):
-        super().__init__(parent, height=60, fg_color="#121212")
+    def __init__(self, parent, title: str = ""):
+        super().__init__(parent, height=60, fg_color=colors.NEUTRAL_800)
         self.pack_propagate(False)
+        self.grid_columnconfigure(0, weight=1)
 
-        # Logo (optionnel)
-        logo_path = os.path.join("assets", "logo.png")
-        if os.path.exists(logo_path):
-            logo_image = ctk.CTkImage(Image.open(logo_path), size=(64, 64))
-            logo_label = ctk.CTkLabel(self, image=logo_image, text="")
-            logo_label.pack(side="left", padx=20)
-
-        # Titre
         self.title_label = ctk.CTkLabel(
             self,
-            text="CoachPro",
-            text_color="#3b82f6",
-            font=ctk.CTkFont(size=20, weight="bold"),
+            text=title,
+            text_color=colors.TEXT,
+            font=fonts.get_title_font(),
         )
-        self.title_label.pack(side="left", padx=10)
+        self.title_label.grid(row=0, column=0, padx=20, pady=10, sticky="w")
 
-        # Profil (optionnel)
-        user_label = ctk.CTkLabel(self, text="👤 Virtus Training", text_color="#bbbbbb")
-        user_label.pack(side="right", padx=20)
+        user_frame = ctk.CTkFrame(self, fg_color="transparent")
+        user_frame.grid(row=0, column=1, padx=20, pady=10, sticky="e")
+        user_icon = load_icon("user1.png", 24)
+        ctk.CTkLabel(
+            user_frame,
+            text="Coach",
+            image=user_icon,
+            compound="left",
+            text_color=colors.TEXT_SECONDARY,
+            font=fonts.get_text_font(),
+        ).pack()
 
-    def update_title(self, new_title):
+    def update_title(self, new_title: str) -> None:
         self.title_label.configure(text=new_title)

--- a/ui/layout/sidebar.py
+++ b/ui/layout/sidebar.py
@@ -5,13 +5,15 @@ import os
 import customtkinter as ctk
 from PIL import Image
 
+from utils.icon_loader import load_icon
+from ui.theme import colors, fonts
+
 
 class Sidebar(ctk.CTkFrame):
-    def __init__(self, parent, switch_page_callback, active_module="dashboard"):
-        super().__init__(parent, width=220, corner_radius=0)
+    def __init__(self, parent, switch_page_callback, active_module: str = "dashboard"):
+        super().__init__(parent, width=220, corner_radius=0, fg_color=colors.NEUTRAL_900)
         self.switch_page_callback = switch_page_callback
         self.active_module = active_module
-        self.configure(fg_color="#1a1a1a")  # Dark theme
 
         self.menu_items = [
             ("dashboard", "Tableau de bord", "layout-dashboard.png"),
@@ -28,42 +30,56 @@ class Sidebar(ctk.CTkFrame):
             ("settings", "Paramètres", "settings.png"),
         ]
 
-        self.create_sidebar()
+        self._build()
 
-    def create_sidebar(self):
-        title = ctk.CTkLabel(
+    def _build(self) -> None:
+        """Create sidebar content."""
+        # Logo
+        logo_path = os.path.join("assets", "Logo.png")
+        if os.path.exists(logo_path):
+            logo_img = ctk.CTkImage(Image.open(logo_path), size=(160, 40))
+            ctk.CTkLabel(self, image=logo_img, text="").pack(pady=(20, 5))
+
+        ctk.CTkLabel(
             self,
             text="CoachPro",
-            text_color="#3b82f6",
-            font=ctk.CTkFont(size=20, weight="bold"),
-        )
-        title.pack(pady=(20, 10))
+            font=fonts.get_title_font(),
+            text_color=colors.PRIMARY,
+        ).pack(pady=(0, 20))
 
         for item_id, item_name, icon_file in self.menu_items:
-            self.add_menu_button(item_id, item_name, icon_file)
+            self._add_button(item_id, item_name, icon_file)
 
-    def add_menu_button(self, item_id, label, icon_filename):
-        image_path = os.path.join("assets", "icons", icon_filename)
-        icon = ctk.CTkImage(Image.open(image_path), size=(18, 18))
-
+    def _add_button(self, item_id: str, label: str, icon_filename: str) -> None:
+        icon = load_icon(icon_filename, 18)
+        is_active = self.active_module == item_id
         button = ctk.CTkButton(
             self,
             text=label,
             image=icon,
             anchor="w",
-            command=lambda: self.on_menu_click(item_id),
-            fg_color="#1a1a1a" if self.active_module != item_id else "#3b82f6",
-            text_color="#f5f5f5" if self.active_module != item_id else "#ffffff",
-            hover_color="#333333",
+            command=lambda i=item_id: self._on_click(i),
+            fg_color=colors.PRIMARY if is_active else "transparent",
+            text_color=colors.NEUTRAL_100 if is_active else colors.TEXT,
+            hover_color=colors.PRIMARY if is_active else colors.NEUTRAL_800,
             corner_radius=0,
             font=ctk.CTkFont(size=14),
             height=40,
         )
         button.pack(fill="x", padx=10, pady=2)
 
-    def on_menu_click(self, module_id):
+    def _on_click(self, module_id: str) -> None:
+        if module_id == self.active_module:
+            return
         self.active_module = module_id
         self.switch_page_callback(module_id)
+        self.refresh()
+
+    def refresh(self) -> None:
         for widget in self.winfo_children():
             widget.destroy()
-        self.create_sidebar()
+        self._build()
+
+    def set_active(self, module_id: str) -> None:
+        self.active_module = module_id
+        self.refresh()

--- a/utils/icon_loader.py
+++ b/utils/icon_loader.py
@@ -1,1 +1,31 @@
+import os
+from typing import Tuple
 
+import customtkinter as ctk
+from PIL import Image
+
+# Simple in-memory cache for loaded icons
+_ICON_CACHE: dict[Tuple[str, Tuple[int, int]], ctk.CTkImage] = {}
+
+
+def load_icon(filename: str, size: Tuple[int, int] | int) -> ctk.CTkImage:
+    """Load an icon from assets/icons with basic caching.
+
+    Parameters
+    ----------
+    filename: str
+        Name of the icon file located in ``assets/icons``.
+    size: tuple[int, int] | int
+        Desired size of the icon. If an int is provided, a square icon is
+        created.
+    """
+
+    if isinstance(size, int):
+        size = (size, size)
+
+    key = (filename, size)
+    if key not in _ICON_CACHE:
+        path = os.path.join("assets", "icons", filename)
+        image = Image.open(path)
+        _ICON_CACHE[key] = ctk.CTkImage(image, size=size)
+    return _ICON_CACHE[key]


### PR DESCRIPTION
## Summary
- add reusable icon loader with caching
- create AppShell layout with persistent sidebar and header
- integrate AppShell into CoachApp routing

## Testing
- `pytest` *(fails: no display name and no $DISPLAY environment variable)*

------
https://chatgpt.com/codex/tasks/task_e_68a715a66f14832aa59fd130c4de6264