### PR TITLE
feat: standardise form modals

### DIFF
--- a/exceptions/validation_error.py
+++ b/exceptions/validation_error.py
@@ -1,0 +1,10 @@
+class ValidationError(Exception):
+    """Exception raised when form validation fails.
+
+    Attributes:
+        errors: mapping of field identifiers to error messages.
+    """
+
+    def __init__(self, errors: dict[str, str]):
+        self.errors = errors
+        super().__init__("Validation failed")

--- a/services/client_service.py
+++ b/services/client_service.py
@@ -1,6 +1,7 @@
 import re
 from typing import List, Optional
 
+from exceptions.validation_error import ValidationError
 from models.client import Client
 from repositories.client_repo import ClientRepository
 
@@ -16,11 +17,16 @@ class ClientService:
         return self.repo.find_by_id(client_id)
 
     def validate_client_data(self, data: dict) -> None:
-        if not data.get("prenom") or not data.get("nom"):
-            raise ValueError("Le nom et le prénom sont obligatoires.")
+        errors: dict[str, str] = {}
+        if not data.get("prenom"):
+            errors["prenom"] = "Le prénom est obligatoire."
+        if not data.get("nom"):
+            errors["nom"] = "Le nom est obligatoire."
         email = data.get("email")
         if email and not re.match(r"^[^@\s]+@[^@\s]+\.[^@\s]+$", email):
-            raise ValueError("L'email est invalide.")
+            errors["email"] = "L'email est invalide."
+        if errors:
+            raise ValidationError(errors)
 
     def add_client(self, client_data: dict) -> None:
         self.validate_client_data(client_data)

--- a/ui/components/design_system/__init__.py
+++ b/ui/components/design_system/__init__.py
@@ -1,5 +1,6 @@
 from .buttons import PrimaryButton, SecondaryButton
 from .cards import Card, InfoCard
+from .forms import LabeledInput
 from .typography import CardTitle, PageTitle
 
 __all__ = [
@@ -7,6 +8,7 @@ __all__ = [
     "SecondaryButton",
     "Card",
     "InfoCard",
+    "LabeledInput",
     "PageTitle",
     "CardTitle",
 ]

--- a/ui/components/design_system/forms.py
+++ b/ui/components/design_system/forms.py
@@ -1,0 +1,43 @@
+"""Form components for the design system."""
+
+import customtkinter as ctk
+
+from ui.theme.colors import DANGER, NEUTRAL_700, TEXT
+from ui.theme.fonts import LABEL_NORMAL, LABEL_SMALL
+
+
+class LabeledInput(ctk.CTkFrame):
+    """Input field with a label and error management."""
+
+    def __init__(self, master, label: str, **entry_kwargs):
+        super().__init__(master, fg_color="transparent")
+        self.columnconfigure(0, weight=1)
+
+        self._label = ctk.CTkLabel(self, text=label, font=LABEL_NORMAL, text_color=TEXT)
+        self._label.grid(row=0, column=0, sticky="w")
+
+        self.entry = ctk.CTkEntry(self, border_color=NEUTRAL_700, **entry_kwargs)
+        self.entry.grid(row=1, column=0, sticky="ew", pady=(0, 4))
+
+        self.error_label = ctk.CTkLabel(
+            self, text="", font=LABEL_SMALL, text_color=DANGER
+        )
+        self.error_label.grid(row=2, column=0, sticky="w")
+        self.error_label.grid_remove()
+
+    def get_value(self) -> str:
+        return self.entry.get().strip()
+
+    def set_value(self, value: str) -> None:
+        self.entry.delete(0, "end")
+        if value is not None:
+            self.entry.insert(0, value)
+
+    def show_error(self, message: str) -> None:
+        self.error_label.configure(text=message)
+        self.error_label.grid()
+        self.entry.configure(border_color=DANGER)
+
+    def hide_error(self) -> None:
+        self.error_label.grid_remove()
+        self.entry.configure(border_color=NEUTRAL_700)

--- a/ui/modals/base_modal.py
+++ b/ui/modals/base_modal.py
@@ -1,0 +1,94 @@
+"""Generic modal window for forms."""
+
+from typing import Any, Callable
+
+import customtkinter as ctk
+
+from exceptions.validation_error import ValidationError
+from ui.components.design_system import PrimaryButton, SecondaryButton
+from ui.theme.colors import DARK_BG, DANGER
+from ui.theme.fonts import LABEL_SMALL
+
+
+class BaseFormModal(ctk.CTkToplevel):
+    """Base modal handling form fields and save/cancel actions.
+
+    Parameters
+    ----------
+    form_fields:
+        Mapping of field identifiers to callables. Each callable receives the
+        form frame as master and must return a widget exposing `get_value`,
+        `set_value`, `show_error` and `hide_error` methods (like
+        :class:`LabeledInput`).
+    """
+
+    def __init__(
+        self,
+        parent,
+        title: str,
+        form_fields: dict[str, Callable[[ctk.CTkFrame], Any]],
+        save_callback: Callable[[dict[str, Any]], None],
+    ) -> None:
+        super().__init__(parent)
+        self.title(title)
+        self.configure(fg_color=DARK_BG)
+        self.geometry("400x200")
+        self.resizable(False, False)
+        self.grab_set()
+
+        form_frame = ctk.CTkFrame(self, fg_color="transparent")
+        form_frame.pack(fill="both", expand=True, padx=20, pady=20)
+        form_frame.grid_columnconfigure(0, weight=1)
+
+        self.form_fields: dict[str, Any] = {
+            key: factory(form_frame) for key, factory in form_fields.items()
+        }
+        self.save_callback = save_callback
+
+        for row, field in enumerate(self.form_fields.values()):
+            field.grid(row=row, column=0, sticky="ew", pady=(0, 10))
+
+        self.general_error_label = ctk.CTkLabel(
+            self, text="", text_color=DANGER, font=LABEL_SMALL
+        )
+        self.general_error_label.pack(padx=20)
+        self.general_error_label.pack_forget()
+
+        button_frame = ctk.CTkFrame(self, fg_color="transparent")
+        button_frame.pack(pady=10)
+
+        SecondaryButton(button_frame, text="Annuler", command=self.destroy).pack(
+            side="left", padx=5
+        )
+        PrimaryButton(button_frame, text="Enregistrer", command=self._on_save).pack(
+            side="left", padx=5
+        )
+
+        self.update_idletasks()
+        self.geometry(f"400x{self.winfo_height()}")
+
+    def _on_save(self) -> None:
+        self._hide_general_error()
+        data: dict[str, Any] = {}
+        for key, field in self.form_fields.items():
+            if hasattr(field, "hide_error"):
+                field.hide_error()
+            value = field.get_value()
+            data[key] = value or None
+        try:
+            self.save_callback(data)
+            self.destroy()
+        except ValidationError as err:
+            for field_id, message in err.errors.items():
+                field = self.form_fields.get(field_id)
+                if field and hasattr(field, "show_error"):
+                    field.show_error(message)
+        except Exception as exc:  # pylint: disable=broad-except
+            self._show_general_error(str(exc))
+
+    def _show_general_error(self, message: str) -> None:
+        self.general_error_label.configure(text=message)
+        self.general_error_label.pack(padx=20, pady=(0, 10))
+
+    def _hide_general_error(self) -> None:
+        self.general_error_label.pack_forget()

--- a/ui/modals/client_form_modal.py
+++ b/ui/modals/client_form_modal.py
@@ -1,109 +1,45 @@
-from tkinter import messagebox
 from typing import Optional
-
-import customtkinter as ctk
 
 from controllers.client_controller import ClientController
 from models.client import Client
-from ui.theme.colors import DARK_BG, TEXT
-from ui.theme.fonts import get_text_font, get_title_font
+from ui.components.design_system import LabeledInput
+from ui.modals.base_modal import BaseFormModal
 
 
-class ClientFormModal(ctk.CTkToplevel):
-    """Fenêtre modale pour ajouter ou modifier un client."""
+class ClientFormModal(BaseFormModal):
+    """Modal for creating or editing a client."""
 
     def __init__(
         self,
         parent,
         controller: ClientController,
-        client_a_modifier: Optional[Client] = None,
-    ):
-        super().__init__(parent)
-        self.client = client_a_modifier
+        client: Optional[Client] = None,
+    ) -> None:
         self.controller = controller
-        self.title("Ajouter/Modifier un client")
-        self.geometry("400x340")
-        self.configure(fg_color=DARK_BG)
-        self.resizable(False, False)
+        self.client = client
 
-        ctk.CTkLabel(
-            self,
-            text="Ajouter/Modifier un client",
-            font=get_title_font(),
-            text_color=TEXT,
-        ).pack(pady=(20, 10))
-
-        form_frame = ctk.CTkFrame(self, fg_color="transparent")
-        form_frame.pack(fill="both", expand=True, padx=20)
-
-        self.prenom_var = ctk.StringVar(value=self.client.prenom if self.client else "")
-        self.nom_var = ctk.StringVar(value=self.client.nom if self.client else "")
-        self.email_var = ctk.StringVar(value=self.client.email if self.client else "")
-        self.date_var = ctk.StringVar(
-            value=self.client.date_naissance if self.client else ""
-        )
-
-        # Champ Prénom
-        ctk.CTkLabel(
-            form_frame, text="Prénom", font=get_text_font(), text_color=TEXT
-        ).pack(anchor="w")
-        ctk.CTkEntry(form_frame, textvariable=self.prenom_var).pack(
-            fill="x", pady=(0, 10)
-        )
-
-        # Champ Nom
-        ctk.CTkLabel(
-            form_frame, text="Nom", font=get_text_font(), text_color=TEXT
-        ).pack(anchor="w")
-        ctk.CTkEntry(form_frame, textvariable=self.nom_var).pack(fill="x", pady=(0, 10))
-
-        # Champ Email
-        ctk.CTkLabel(
-            form_frame, text="Email", font=get_text_font(), text_color=TEXT
-        ).pack(anchor="w")
-        ctk.CTkEntry(form_frame, textvariable=self.email_var).pack(
-            fill="x", pady=(0, 10)
-        )
-
-        # Champ Date de naissance
-        ctk.CTkLabel(
-            form_frame,
-            text="Date de Naissance (AAAA-MM-JJ)",
-            font=get_text_font(),
-            text_color=TEXT,
-        ).pack(anchor="w")
-        ctk.CTkEntry(form_frame, textvariable=self.date_var).pack(
-            fill="x", pady=(0, 10)
-        )
-
-        btn_frame = ctk.CTkFrame(self, fg_color="transparent")
-        btn_frame.pack(pady=10)
-
-        ctk.CTkButton(btn_frame, text="Enregistrer", command=self._on_save).pack(
-            side="left", padx=5
-        )
-        ctk.CTkButton(btn_frame, text="Annuler", command=self.destroy).pack(
-            side="left", padx=5
-        )
-
-    def _on_save(self) -> None:
-        prenom = self.prenom_var.get().strip()
-        nom = self.nom_var.get().strip()
-        email = self.email_var.get().strip() or None
-        date_naissance = self.date_var.get().strip() or None
-
-        client_data = {
-            "prenom": prenom,
-            "nom": nom,
-            "email": email,
-            "date_naissance": date_naissance,
+        fields = {
+            "prenom": lambda master: LabeledInput(master, "Prénom"),
+            "nom": lambda master: LabeledInput(master, "Nom"),
+            "email": lambda master: LabeledInput(master, "Email"),
+            "date_naissance": lambda master: LabeledInput(
+                master, "Date de Naissance (AAAA-MM-JJ)"
+            ),
         }
 
-        try:
-            if self.client:
-                self.controller.update_client(self.client.id, client_data)
-            else:
-                self.controller.add_client(client_data)
-            self.destroy()
-        except ValueError as e:
-            messagebox.showerror("Erreur", str(e))
+        if client:
+            save_callback = lambda data: controller.update_client(client.id, data)
+            title = "Modifier un client"
+        else:
+            save_callback = controller.add_client
+            title = "Ajouter un client"
+
+        super().__init__(parent, title, fields, save_callback)
+
+        if client:
+            self.form_fields["prenom"].set_value(client.prenom)
+            self.form_fields["nom"].set_value(client.nom)
+            self.form_fields["email"].set_value(client.email or "")
+            self.form_fields["date_naissance"].set_value(
+                client.date_naissance or ""
+            )

--- a/ui/theme/fonts.py
+++ b/ui/theme/fonts.py
@@ -16,6 +16,7 @@ H2_BOLD = (FONT_FAMILY, 24, "bold")
 H3_NORMAL = (FONT_FAMILY, 18, "normal")
 BODY_NORMAL = (FONT_FAMILY, 16, "normal")
 LABEL_NORMAL = (FONT_FAMILY, 14, "normal")
+LABEL_SMALL = (FONT_FAMILY, 11, "normal")
 CARD_TITLE = (FONT_FAMILY, 16, "bold")
 
 
@@ -45,7 +46,7 @@ def get_text_font():
 def get_small_font():
     """Return small label font."""
 
-    return LABEL_NORMAL
+    return LABEL_SMALL
 
 
 def get_button_font():
@@ -61,6 +62,7 @@ __all__ = [
     "H3_NORMAL",
     "BODY_NORMAL",
     "LABEL_NORMAL",
+    "LABEL_SMALL",
     "CARD_TITLE",
     "get_title_font",
     "get_section_font",


### PR DESCRIPTION
## Summary
- add LABEL_SMALL font token
- introduce ValidationError and use in client service
- create LabeledInput component
- implement BaseFormModal and refactor ClientFormModal

## Testing
- `pytest` *(fails: no display name and no $DISPLAY environment variable)*

------
https://chatgpt.com/codex/tasks/task_e_68a71b2e8a88832a89290906564f334b