### PR TITLE
feat: persist generated sessions

### DIFF
--- a/app.py
+++ b/app.py
@@ -4,13 +4,16 @@ import customtkinter as ctk
 
 from controllers.client_controller import ClientController
 from controllers.nutrition_controller import NutritionController
+from controllers.session_controller import SessionController
 from repositories.aliment_repo import AlimentRepository
 from repositories.client_repo import ClientRepository
 from repositories.fiche_nutrition_repo import FicheNutritionRepository
 from repositories.plan_alimentaire_repo import PlanAlimentaireRepository
+from repositories.sessions_repo import SessionsRepository
 from services.client_service import ClientService
 from services.nutrition_service import NutritionService
 from services.plan_alimentaire_service import PlanAlimentaireService
+from services.session_service import SessionService
 from ui.layout.app_shell import AppShell
 from ui.pages.billing_page import BillingPage
 from ui.pages.calendar_page import CalendarPage
@@ -52,6 +55,10 @@ class CoachApp(ctk.CTk):
             nutrition_service, plan_service, client_service
         )
 
+        sessions_repo = SessionsRepository()
+        session_service = SessionService(sessions_repo)
+        self.session_controller = SessionController(session_service)
+
         self.page_titles = {
             "dashboard": "Tableau de bord",
             "programs": "Programmes",
@@ -79,7 +86,9 @@ class CoachApp(ctk.CTk):
             case "programs":
                 self.current_page = ProgramPage(self.shell.content_area)
             case "sessions":
-                self.current_page = SessionPage(self.shell.content_area)
+                self.current_page = SessionPage(
+                    self.shell.content_area, self.session_controller
+                )
             case "calendar":
                 self.current_page = CalendarPage(self.shell.content_area)
             case "nutrition":

--- a/controllers/session_controller.py
+++ b/controllers/session_controller.py
@@ -1,4 +1,4 @@
-"""Controller utilities for session preview generation."""
+"""Controller handling session preview generation and persistence."""
 
 from __future__ import annotations
 
@@ -6,81 +6,89 @@ from typing import Any, Dict, Tuple
 
 from repositories.exercices_repo import ExerciseRepository
 from services.session_generator import generate_collectif
+from services.session_service import SessionService
 
 
-def build_session_preview_dto(
-    blocks: list[Any], exercises_by_id: Dict[str, Dict[str, Any]]
-) -> Dict[str, Any]:
-    """Map session blocks to a DTO consumable by the view."""
-    blocks_out: list[Dict[str, Any]] = []
-    for blk in blocks:
-        title = (
-            f"{blk.type} — {blk.duration_sec // 60}’" if blk.duration_sec else blk.type
-        )
-        block_dto = {
-            "title": title,
-            "format": blk.type,
-            "duration": f"{blk.duration_sec // 60}’" if blk.duration_sec else "",
-            "exercises": [],
-        }
-        for item in blk.items:
-            meta = exercises_by_id.get(item.exercise_id, {})
-            name = meta.get("name", f"Exercice #{item.exercise_id}")
-            muscle = meta.get("primary_muscle", "")
-            equip = " / ".join(meta.get("equipment", []))
-            presc = item.prescription or {}
-            reps = None
-            if "reps" in presc:
-                reps = f"{presc['reps']} reps"
-            elif "work_sec" in presc:
-                reps = f"{presc['work_sec']}s"
-            exercise = {
-                "id": item.exercise_id,
-                "nom": name,
-                "reps": reps,
-                "repos_s": presc.get("rest_sec"),
-                "muscle": muscle,
-                "equip": equip,
+class SessionController:
+    def __init__(self, session_service: SessionService) -> None:
+        self.session_service = session_service
+
+    def build_session_preview_dto(
+        self, blocks: list[Any], exercises_by_id: Dict[str, Dict[str, Any]]
+    ) -> Dict[str, Any]:
+        """Map session blocks to a DTO consumable by the view."""
+        blocks_out: list[Dict[str, Any]] = []
+        for blk in blocks:
+            title = (
+                f"{blk.type} — {blk.duration_sec // 60}’" if blk.duration_sec else blk.type
+            )
+            block_dto = {
+                "title": title,
+                "format": blk.type,
+                "duration": f"{blk.duration_sec // 60}’" if blk.duration_sec else "",
+                "exercises": [],
             }
-            block_dto["exercises"].append(exercise)
-        blocks_out.append(block_dto)
-    return {"blocks": blocks_out}
+            for item in blk.items:
+                meta = exercises_by_id.get(item.exercise_id, {})
+                name = meta.get("name", f"Exercice #{item.exercise_id}")
+                muscle = meta.get("primary_muscle", "")
+                equip = " / ".join(meta.get("equipment", []))
+                presc = item.prescription or {}
+                reps = None
+                if "reps" in presc:
+                    reps = f"{presc['reps']} reps"
+                elif "work_sec" in presc:
+                    reps = f"{presc['work_sec']}s"
+                exercise = {
+                    "id": item.exercise_id,
+                    "nom": name,
+                    "reps": reps,
+                    "repos_s": presc.get("rest_sec"),
+                    "muscle": muscle,
+                    "equip": equip,
+                }
+                block_dto["exercises"].append(exercise)
+            blocks_out.append(block_dto)
+        return {"blocks": blocks_out}
+
+    def generate_session_preview(
+        self, params: Dict[str, Any], mode: str = "collectif"
+    ) -> Tuple[Any, Dict[str, Any]]:
+        """Generate a session and its preview DTO."""
+        if mode == "collectif":
+            svc_params = {
+                "course_type": params.get("course_type"),
+                "duration": int(params.get("duration", 0)),
+                "intensity": params.get("intensity"),
+                "equipment": params.get("equipment", []),
+            }
+            session = generate_collectif(svc_params)
+            ids = [it.exercise_id for b in session.blocks for it in b.items]
+            repo = ExerciseRepository()
+            meta = repo.get_meta_by_ids(ids)
+            dto = self.build_session_preview_dto(session.blocks, meta)
+            dto["meta"] = {
+                "title": session.label,
+                "duration": f"{session.duration_sec // 60} min",
+            }
+            return session, dto
+        elif mode == "individuel":
+            session = {"client": params.get("client"), "goal": params.get("goal")}
+            dto = {
+                "meta": {
+                    "title": f"Séance pour {session['client']}",
+                    "goal": session["goal"],
+                    "duration": "45 min",
+                },
+                "blocks": [],
+            }
+            return session, dto
+        else:
+            raise ValueError(f"Unknown mode: {mode}")
+
+    def save_session(self, session_dto: Dict[str, Any], client_id: int | None) -> None:
+        """Persist a generated session from its DTO representation."""
+        self.session_service.save_session_from_dto(session_dto, client_id)
 
 
-def generate_session_preview(
-    params: Dict[str, Any], mode: str = "collectif"
-) -> Tuple[Any, Dict[str, Any]]:
-    """Generate a session and its preview DTO."""
-    if mode == "collectif":
-        svc_params = {
-            "course_type": params.get("course_type"),
-            "duration": int(params.get("duration", 0)),
-            "intensity": params.get("intensity"),
-            "equipment": params.get("equipment", []),
-        }
-        session = generate_collectif(svc_params)
-        ids = [it.exercise_id for b in session.blocks for it in b.items]
-        repo = ExerciseRepository()
-        meta = repo.get_meta_by_ids(ids)
-        dto = build_session_preview_dto(session.blocks, meta)
-        dto["meta"] = {
-            "title": session.label,
-            "duration": f"{session.duration_sec // 60} min",
-        }
-        return session, dto
-    elif mode == "individuel":
-        session = {"client": params.get("client"), "goal": params.get("goal")}
-        dto = {
-            "meta": {
-                "title": f"Séance pour {session['client']}",
-                "goal": session["goal"],
-                "duration": "45 min",
-            },
-            "blocks": [],
-        }
-        return session, dto
-    else:
-        raise ValueError(f"Unknown mode: {mode}")
-
-
-__all__ = ["build_session_preview_dto", "generate_session_preview"]
+__all__ = ["SessionController"]

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -127,3 +127,34 @@ CREATE TABLE fiches_nutrition (
     FOREIGN KEY(client_id) REFERENCES clients(id)
 );
 
+CREATE TABLE sessions (
+    session_id TEXT PRIMARY KEY,
+    client_id INTEGER,
+    mode TEXT NOT NULL,
+    label TEXT NOT NULL,
+    duration_sec INTEGER NOT NULL,
+    FOREIGN KEY(client_id) REFERENCES clients(id)
+);
+
+CREATE TABLE session_blocks (
+    block_id TEXT PRIMARY KEY,
+    session_id TEXT NOT NULL,
+    type TEXT NOT NULL,
+    duration_sec INTEGER,
+    rounds INTEGER,
+    work_sec INTEGER,
+    rest_sec INTEGER,
+    title TEXT,
+    locked INTEGER DEFAULT 0,
+    FOREIGN KEY(session_id) REFERENCES sessions(session_id)
+);
+
+CREATE TABLE session_items (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    block_id TEXT NOT NULL,
+    exercise_id TEXT NOT NULL,
+    prescription TEXT NOT NULL,
+    notes TEXT,
+    FOREIGN KEY(block_id) REFERENCES session_blocks(block_id)
+);
+

--- a/models/session.py
+++ b/models/session.py
@@ -30,5 +30,6 @@ class Session:
     mode: str  # COLLECTIF / INDIVIDUEL
     label: str
     duration_sec: int
+    client_id: Optional[int] = None
     blocks: List[Block] = field(default_factory=list)
     meta: Dict[str, Number | str] = field(default_factory=dict)

--- a/repositories/sessions_repo.py
+++ b/repositories/sessions_repo.py
@@ -7,36 +7,41 @@ from models.session import Session
 class SessionsRepository:
     def save(self, s: Session) -> None:
         with db_manager.get_connection() as conn:
-            conn.execute(
-                "INSERT OR REPLACE INTO sessions(session_id, mode, label, duration_sec) VALUES (?,?,?,?)",
-                (s.session_id, s.mode, s.label, s.duration_sec),
-            )
-            for b in s.blocks:
+            try:
+                conn.execute("BEGIN")
                 conn.execute(
-                    """INSERT OR REPLACE INTO session_blocks
-                    (block_id, session_id, type, duration_sec, rounds, work_sec, rest_sec, title, locked)
-                    VALUES (?,?,?,?,?,?,?,?,?)""",
-                    (
-                        b.block_id,
-                        s.session_id,
-                        b.type,
-                        b.duration_sec,
-                        b.rounds,
-                        b.work_sec,
-                        b.rest_sec,
-                        b.title,
-                        int(b.locked),
-                    ),
+                    "INSERT OR REPLACE INTO sessions(session_id, client_id, mode, label, duration_sec) VALUES (?,?,?,?,?)",
+                    (s.session_id, s.client_id, s.mode, s.label, s.duration_sec),
                 )
-                for it in b.items:
+                for b in s.blocks:
                     conn.execute(
-                        """INSERT INTO session_items(block_id, exercise_id, prescription, notes)
-                                    VALUES (?,?,?,?)""",
+                        """INSERT OR REPLACE INTO session_blocks
+                        (block_id, session_id, type, duration_sec, rounds, work_sec, rest_sec, title, locked)
+                        VALUES (?,?,?,?,?,?,?,?,?)""",
                         (
                             b.block_id,
-                            it.exercise_id,
-                            json.dumps(it.prescription, ensure_ascii=False),
-                            it.notes or None,
+                            s.session_id,
+                            b.type,
+                            b.duration_sec,
+                            b.rounds,
+                            b.work_sec,
+                            b.rest_sec,
+                            b.title,
+                            int(b.locked),
                         ),
                     )
-            conn.commit()
+                    for it in b.items:
+                        conn.execute(
+                            """INSERT INTO session_items(block_id, exercise_id, prescription, notes)
+                                        VALUES (?,?,?,?)""",
+                            (
+                                b.block_id,
+                                it.exercise_id,
+                                json.dumps(it.prescription, ensure_ascii=False),
+                                it.notes or None,
+                            ),
+                        )
+                conn.commit()
+            except Exception:
+                conn.rollback()
+                raise

--- a/services/session_service.py
+++ b/services/session_service.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+import re
+import uuid
+from typing import Any, Dict, Optional
+
+from models.session import Block, BlockItem, Session
+from repositories.sessions_repo import SessionsRepository
+
+
+class SessionService:
+    def __init__(self, repo: SessionsRepository) -> None:
+        self.repo = repo
+
+    def save_session_from_dto(self, session_dto: Dict[str, Any], client_id: Optional[int]) -> None:
+        session = self._dto_to_session(session_dto, client_id)
+        self.repo.save(session)
+
+    def _dto_to_session(self, dto: Dict[str, Any], client_id: Optional[int]) -> Session:
+        session_id = uuid.uuid4().hex
+        meta = dto.get("meta", {})
+        label = meta.get("title", "Séance")
+        duration_sec = self._parse_minutes(meta.get("duration")) * 60
+        mode = "INDIVIDUEL" if client_id else "COLLECTIF"
+        session = Session(
+            session_id=session_id,
+            client_id=client_id,
+            mode=mode,
+            label=label,
+            duration_sec=duration_sec,
+            blocks=[],
+            meta={},
+        )
+        for idx, blk in enumerate(dto.get("blocks", []), start=1):
+            block_id = f"{session_id}-b{idx}"
+            block = Block(
+                block_id=block_id,
+                type=blk.get("format", ""),
+                duration_sec=self._parse_minutes(blk.get("duration")) * 60,
+                title=blk.get("title"),
+                items=[],
+            )
+            for ex in blk.get("exercises", []):
+                prescription: Dict[str, Any] = {}
+                reps = ex.get("reps")
+                if isinstance(reps, str):
+                    if "reps" in reps:
+                        prescription["reps"] = self._parse_int(reps)
+                    elif reps.endswith("s"):
+                        prescription["work_sec"] = self._parse_int(reps)
+                rest = ex.get("repos_s")
+                if rest is not None:
+                    prescription["rest_sec"] = rest
+                item = BlockItem(
+                    exercise_id=str(ex.get("id")),
+                    prescription=prescription,
+                )
+                block.items.append(item)
+            session.blocks.append(block)
+        return session
+
+    @staticmethod
+    def _parse_minutes(text: Optional[str]) -> int:
+        if not text:
+            return 0
+        digits = re.findall(r"\d+", text)
+        return int(digits[0]) if digits else 0
+
+    @staticmethod
+    def _parse_int(text: str) -> int:
+        digits = re.findall(r"\d+", text)
+        return int(digits[0]) if digits else 0

--- a/ui/pages/session_page.py
+++ b/ui/pages/session_page.py
@@ -2,7 +2,7 @@
 
 import customtkinter as ctk
 
-from controllers import session_controller
+from controllers.session_controller import SessionController
 from repositories.client_repo import ClientRepository
 from services.client_service import ClientService
 from ui.components.design_system.typography import PageTitle
@@ -15,8 +15,9 @@ from .session_page_components.session_preview import SessionPreview
 class SessionPage(ctk.CTkFrame):
     """Page principale pour la génération de séances."""
 
-    def __init__(self, parent):
+    def __init__(self, parent, session_controller: SessionController):
         super().__init__(parent)
+        self.session_controller = session_controller
         self.grid_rowconfigure(1, weight=1)
         self.grid_columnconfigure((0, 1), weight=1)
 
@@ -41,10 +42,12 @@ class SessionPage(ctk.CTkFrame):
         self.form_individuel.pack(fill="both", expand=True, padx=16, pady=16)
 
         # Aperçu de la séance
-        self.preview_panel = SessionPreview(self)
+        self.preview_panel = SessionPreview(self, self.session_controller)
         self.preview_panel.grid(row=1, column=1, sticky="nsew", padx=(8, 16), pady=16)
 
     def on_generate_collectif(self) -> None:
         params = self.form_collectif.get_params()
-        _, dto = session_controller.generate_session_preview(params, mode="collectif")
-        self.preview_panel.render_session(dto)
+        _, dto = self.session_controller.generate_session_preview(
+            params, mode="collectif"
+        )
+        self.preview_panel.render_session(dto, client_id=None)

--- a/ui/pages/session_page_components/session_preview.py
+++ b/ui/pages/session_page_components/session_preview.py
@@ -6,13 +6,15 @@ import customtkinter as ctk
 
 from ui.components.design_system import Card, CardTitle, PrimaryButton
 from ui.components.workout_block import WorkoutBlock
+from controllers.session_controller import SessionController
 
 
 class SessionPreview(ctk.CTkFrame):
     """Display area for generated session details."""
 
-    def __init__(self, parent) -> None:
+    def __init__(self, parent, controller: SessionController) -> None:
         super().__init__(parent)
+        self.controller = controller
         self.grid_rowconfigure(0, weight=1)
         self.grid_columnconfigure(0, weight=1)
 
@@ -20,8 +22,10 @@ class SessionPreview(ctk.CTkFrame):
         self._content.grid(row=0, column=0, sticky="nsew", padx=8, pady=8)
 
         self._last_dto: dict | None = None
+        self._client_id: int | None = None
         self._grid: ctk.CTkFrame | None = None
         self._blocks: list[WorkoutBlock] = []
+        self._save_btn: PrimaryButton | None = None
         self.show_empty_state()
 
     def show_empty_state(self) -> None:
@@ -34,9 +38,10 @@ class SessionPreview(ctk.CTkFrame):
             justify="center",
         ).pack(expand=True, padx=16, pady=16)
 
-    def render_session(self, session_dto: dict) -> None:
+    def render_session(self, session_dto: dict, client_id: int | None = None) -> None:
         """Render the session preview from a DTO."""
         self._last_dto = session_dto
+        self._client_id = client_id
         for w in self._content.winfo_children():
             w.destroy()
 
@@ -78,9 +83,10 @@ class SessionPreview(ctk.CTkFrame):
         self.after(10, self._arrange_blocks)
         self._grid.bind("<Configure>", lambda e: self._arrange_blocks())
 
-        PrimaryButton(
+        self._save_btn = PrimaryButton(
             self._content, text="Enregistrer la séance", command=self._on_save
-        ).pack(padx=8, pady=12, anchor="e")
+        )
+        self._save_btn.pack(padx=8, pady=12, anchor="e")
 
     def _arrange_blocks(self) -> None:
         """Place workout blocks in a responsive grid."""
@@ -104,8 +110,12 @@ class SessionPreview(ctk.CTkFrame):
         for c in range(cols):
             self._grid.grid_columnconfigure(c, weight=1)
 
-    def _on_save(self) -> None:  # pragma: no cover - placeholder
-        pass
+    def _on_save(self) -> None:  # pragma: no cover - UI callback
+        if not self._last_dto or not self._save_btn:
+            return
+        self._save_btn.configure(state="disabled")
+        self.controller.save_session(self._last_dto, self._client_id)
+        print("Séance enregistrée !")
 
 
 __all__ = ["SessionPreview"]


### PR DESCRIPTION
## Summary
- add SessionService to transform preview DTOs into database models
- wire SessionController and UI to save sessions
- store sessions, blocks and exercises transactionally

## Testing
- `pytest` *(fails: no display name and no $DISPLAY environment variable)*

------
https://chatgpt.com/codex/tasks/task_e_68a741e4f5fc832a8d24e8ef40366964