### PR TITLE
feat: add individual session generator

### DIFF
--- a/services/client_service.py
+++ b/services/client_service.py
@@ -16,6 +16,14 @@ class ClientService:
     def get_client_by_id(self, client_id: int) -> Optional[Client]:
         return self.repo.find_by_id(client_id)
 
+    def get_client_with_exclusions(self, client_id: int) -> tuple[Client, List[int]]:
+        """Return a client and the list of excluded exercise IDs."""
+        client = self.get_client_by_id(client_id)
+        if not client:
+            raise ValueError("Client introuvable")
+        exclusions = self.get_client_exclusions(client_id)
+        return client, exclusions
+
     def validate_client_data(self, data: dict) -> None:
         errors: dict[str, str] = {}
         if not data.get("prenom"):

--- a/ui/pages/session_page.py
+++ b/ui/pages/session_page.py
@@ -2,6 +2,7 @@
 
 import customtkinter as ctk
 
+from controllers.client_controller import ClientController
 from controllers.session_controller import SessionController
 from repositories.client_repo import ClientRepository
 from services.client_service import ClientService
@@ -37,8 +38,11 @@ class SessionPage(ctk.CTkFrame):
         )
         self.form_collectif.pack(fill="both", expand=True, padx=16, pady=16)
 
-        client_service = ClientService(ClientRepository())
-        self.form_individuel = FormIndividuel(individuel_tab, client_service)
+        client_controller = ClientController(ClientService(ClientRepository()))
+        clients = client_controller.get_all_clients_for_view()
+        self.form_individuel = FormIndividuel(
+            individuel_tab, clients, generate_callback=self.on_generate_individual
+        )
         self.form_individuel.pack(fill="both", expand=True, padx=16, pady=16)
 
         # Aperçu de la séance
@@ -51,3 +55,10 @@ class SessionPage(ctk.CTkFrame):
             params, mode="collectif"
         )
         self.preview_panel.render_session(dto, client_id=None)
+
+    def on_generate_individual(self) -> None:
+        params = self.form_individuel.get_params()
+        _, dto = self.session_controller.generate_individual_session(
+            params["client_id"], params["objectif"], params["duree_minutes"]
+        )
+        self.preview_panel.render_session(dto, client_id=params["client_id"])

--- a/ui/pages/session_page_components/form_individuel.py
+++ b/ui/pages/session_page_components/form_individuel.py
@@ -1,8 +1,10 @@
 """UI components for individual session generation form."""
 
+from typing import List
+
 import customtkinter as ctk
 
-from services.client_service import ClientService
+from models.client import Client
 from ui.components.design_system.buttons import PrimaryButton
 from ui.components.design_system.cards import Card
 from ui.components.design_system.typography import CardTitle
@@ -11,7 +13,7 @@ from ui.components.design_system.typography import CardTitle
 class FormIndividuel(Card):
     """Formulaire pour la génération de séances individuelles."""
 
-    def __init__(self, parent, client_service: ClientService, generate_callback=None):
+    def __init__(self, parent, clients: List[Client], generate_callback=None):
         super().__init__(parent)
         self.grid_columnconfigure(0, weight=1)
 
@@ -27,17 +29,16 @@ class FormIndividuel(Card):
         ctk.CTkLabel(client_row, text="Client").grid(
             row=0, column=0, sticky="w", padx=(0, 8)
         )
-        self.client_service = client_service
-        clients = self.client_service.get_all_clients()
-        client_names = [f"{c.prenom} {c.nom}" for c in clients]
+        self._client_map = {f"{c.prenom} {c.nom}": c.id for c in clients}
+        client_names = list(self._client_map.keys())
         self.client_var = ctk.StringVar(value=client_names[0] if client_names else "")
-        ctk.CTkOptionMenu(
+        ctk.CTkComboBox(
             client_row, variable=self.client_var, values=client_names
         ).grid(row=0, column=1, sticky="ew")
 
         # Objectif de la séance
         objective_row = ctk.CTkFrame(self, fg_color="transparent")
-        objective_row.grid(row=2, column=0, sticky="ew", padx=16, pady=(0, 16))
+        objective_row.grid(row=2, column=0, sticky="ew", padx=16, pady=(0, 8))
         objective_row.grid_columnconfigure(1, weight=1)
 
         ctk.CTkLabel(objective_row, text="Objectif").grid(
@@ -48,14 +49,34 @@ class FormIndividuel(Card):
             row=0, column=1, sticky="ew"
         )
 
+        # Durée de la séance
+        duration_row = ctk.CTkFrame(self, fg_color="transparent")
+        duration_row.grid(row=3, column=0, sticky="ew", padx=16, pady=(0, 16))
+        duration_row.grid_columnconfigure(1, weight=1)
+        ctk.CTkLabel(duration_row, text="Durée").grid(
+            row=0, column=0, sticky="w", padx=(0, 8)
+        )
+        duration_values = [
+            "30 minutes",
+            "45 minutes",
+            "60 minutes",
+            "75 minutes",
+            "90 minutes",
+        ]
+        self.duration_var = ctk.StringVar(value=duration_values[0])
+        ctk.CTkOptionMenu(
+            duration_row, variable=self.duration_var, values=duration_values
+        ).grid(row=0, column=1, sticky="ew")
+
         # Action button
         PrimaryButton(self, text="Générer la séance", command=generate_callback).grid(
-            row=3, column=0, sticky="ew", padx=16, pady=(0, 16)
+            row=4, column=0, sticky="ew", padx=16, pady=(0, 16)
         )
 
     def get_params(self) -> dict:
         """Retourne les paramètres du formulaire."""
         return {
-            "client": self.client_var.get(),
-            "goal": self.objective_var.get(),
+            "client_id": self._client_map.get(self.client_var.get()),
+            "objectif": self.objective_var.get(),
+            "duree_minutes": int(self.duration_var.get().split()[0]),
         }


### PR DESCRIPTION
## Summary
- add engine to generate individual sessions with client exclusions
- allow selecting clients and duration in individual session form
- connect individual session flow from UI to controller

## Testing
- `pytest` *(fails: no display name and no $DISPLAY environment variable)*

------
https://chatgpt.com/codex/tasks/task_e_68a7462d606c832ab738e90e546d16db