### PR TITLE
feat: interactive calendar modal

### DIFF
--- a/app.py
+++ b/app.py
@@ -72,7 +72,9 @@ class CoachApp(ctk.CTk):
         )
 
         calendar_service = CalendarService(sessions_repo)
-        self.calendar_controller = CalendarController(calendar_service)
+        self.calendar_controller = CalendarController(
+            calendar_service, session_service
+        )
 
         self.page_titles = {
             "dashboard": "Tableau de bord",
@@ -108,7 +110,9 @@ class CoachApp(ctk.CTk):
                 )
             case "calendar":
                 self.current_page = CalendarPage(
-                    self.shell.content_area, self.calendar_controller
+                    self.shell.content_area,
+                    self.calendar_controller,
+                    self.session_controller,
                 )
             case "nutrition":
                 self.current_page = NutritionPage(

--- a/controllers/calendar_controller.py
+++ b/controllers/calendar_controller.py
@@ -5,16 +5,23 @@ from typing import Dict, List
 
 from models.session import Session
 from services.calendar_service import CalendarService
+from services.session_service import SessionService
 
 
 class CalendarController:
-    def __init__(self, service: CalendarService) -> None:
-        self.service = service
+    def __init__(
+        self, calendar_service: CalendarService, session_service: SessionService
+    ) -> None:
+        self.calendar_service = calendar_service
+        self.session_service = session_service
 
     def get_calendar_data(self, year: int, month: int) -> Dict[int, List[Session]]:
-        sessions = self.service.get_sessions_for_month(year, month)
+        sessions = self.calendar_service.get_sessions_for_month(year, month)
         data: Dict[int, List[Session]] = {}
         for s in sessions:
             day = datetime.fromisoformat(s.date_creation).day
             data.setdefault(day, []).append(s)
         return data
+
+    def get_session_details(self, session_id: str) -> Session | None:
+        return self.session_service.get_session_by_id(session_id)

--- a/controllers/session_controller.py
+++ b/controllers/session_controller.py
@@ -9,6 +9,7 @@ from services.exercise_service import ExerciseService
 from services.pdf_generator import generate_session_pdf
 from services.session_generator import generate_collectif, generate_individuel
 from services.session_service import SessionService
+from models.session import Session
 
 
 class SessionController:
@@ -95,6 +96,16 @@ class SessionController:
             "duration": f"{session.duration_sec // 60} min",
         }
         return session, dto
+
+    def build_preview_from_session(self, session: Session) -> Dict[str, Any]:
+        ids = [it.exercise_id for b in session.blocks for it in b.items]
+        meta = self.exercise_service.get_meta_by_ids(ids)
+        dto = self.build_session_preview_dto(session.blocks, meta)
+        dto["meta"] = {
+            "title": session.label,
+            "duration": f"{session.duration_sec // 60} min",
+        }
+        return dto
 
     def save_session(self, session_dto: Dict[str, Any], client_id: int | None) -> None:
         """Persist a generated session from its DTO representation."""

--- a/services/session_service.py
+++ b/services/session_service.py
@@ -18,6 +18,9 @@ class SessionService:
         session = self._dto_to_session(session_dto, client_id)
         self.repo.save(session)
 
+    def get_session_by_id(self, session_id: str) -> Session | None:
+        return self.repo.get_by_id(session_id)
+
     def _dto_to_session(self, dto: Dict[str, Any], client_id: Optional[int]) -> Session:
         session_id = uuid.uuid4().hex
         meta = dto.get("meta", {})

--- a/ui/components/calendar_view.py
+++ b/ui/components/calendar_view.py
@@ -31,8 +31,10 @@ class CalendarView(ctk.CTkFrame):
         parent,
         on_previous_month: Callable[[], None],
         on_next_month: Callable[[], None],
+        on_session_click: Callable[[str], None] | None = None,
     ) -> None:
         super().__init__(parent)
+        self.on_session_click = on_session_click
 
         header = ctk.CTkFrame(self)
         header.pack(fill="x", pady=5)
@@ -80,6 +82,15 @@ class CalendarView(ctk.CTkFrame):
                     continue
                 ctk.CTkLabel(cell, text=str(day)).pack(anchor="ne", padx=2, pady=2)
                 for sess in data.get(day, []):
-                    ctk.CTkLabel(cell, text=sess.label, anchor="w").pack(
-                        anchor="w", padx=2
-                    )
+                    ctk.CTkButton(
+                        cell,
+                        text=sess.label,
+                        anchor="w",
+                        command=lambda sid=sess.session_id: self._handle_session_click(
+                            sid
+                        ),
+                    ).pack(anchor="w", padx=2)
+
+    def _handle_session_click(self, session_id: str) -> None:
+        if self.on_session_click:
+            self.on_session_click(session_id)

--- a/ui/modals/session_detail_modal.py
+++ b/ui/modals/session_detail_modal.py
@@ -1,0 +1,46 @@
+import customtkinter as ctk
+from tkinter import filedialog
+
+from controllers.session_controller import SessionController
+from models.session import Session
+from ui.components.design_system import PrimaryButton, SecondaryButton
+from ui.pages.session_page_components.session_preview import SessionPreview
+from ui.theme.colors import DARK_BG
+
+
+class SessionDetailModal(ctk.CTkToplevel):
+    def __init__(self, parent, session: Session, controller: SessionController) -> None:
+        super().__init__(parent)
+        self.session = session
+        self.controller = controller
+        self.configure(fg_color=DARK_BG)
+        self.title(session.label)
+        self.geometry("700x600")
+        self.resizable(False, False)
+        self.grab_set()
+
+        self.dto = self.controller.build_preview_from_session(session)
+        self.preview = SessionPreview(self, controller, show_action_buttons=False)
+        self.preview.pack(fill="both", expand=True, padx=10, pady=10)
+        self.preview.render_session(self.dto, session.client_id)
+
+        footer = ctk.CTkFrame(self, fg_color="transparent")
+        footer.pack(pady=10)
+        PrimaryButton(footer, text="Exporter en PDF", command=self._on_export_pdf).pack(
+            side="right", padx=5
+        )
+        SecondaryButton(footer, text="Fermer", command=self.destroy).pack(
+            side="right", padx=5
+        )
+
+    def _on_export_pdf(self) -> None:  # pragma: no cover - UI callback
+        path = filedialog.asksaveasfilename(
+            defaultextension=".pdf", filetypes=[("PDF", "*.pdf")]
+        )
+        if path:
+            self.controller.export_session_to_pdf(
+                self.dto, self.session.client_id, path
+            )
+
+
+__all__ = ["SessionDetailModal"]

--- a/ui/pages/calendar_page.py
+++ b/ui/pages/calendar_page.py
@@ -4,21 +4,29 @@ import datetime
 import customtkinter as ctk
 
 from controllers.calendar_controller import CalendarController
+from controllers.session_controller import SessionController
 from ui.components.calendar_view import CalendarView
+from ui.modals.session_detail_modal import SessionDetailModal
 from ui.theme.fonts import get_section_font
 
 
 class CalendarPage(ctk.CTkFrame):
-    def __init__(self, parent, controller: CalendarController):
+    def __init__(
+        self,
+        parent,
+        controller: CalendarController,
+        session_controller: SessionController,
+    ):
         super().__init__(parent)
         self.controller = controller
+        self.session_controller = session_controller
         today = datetime.date.today()
         self.year = today.year
         self.month = today.month
 
         ctk.CTkLabel(self, text="Planning", font=get_section_font()).pack(pady=5)
         self.calendar = CalendarView(
-            self, self.on_previous_month, self.on_next_month
+            self, self.on_previous_month, self.on_next_month, self.on_session_click
         )
         self.calendar.pack(fill="both", expand=True)
         self._refresh()
@@ -26,6 +34,11 @@ class CalendarPage(ctk.CTkFrame):
     def _refresh(self) -> None:
         data = self.controller.get_calendar_data(self.year, self.month)
         self.calendar.set_data(self.year, self.month, data)
+
+    def on_session_click(self, session_id: str) -> None:
+        session = self.controller.get_session_details(session_id)
+        if session:
+            SessionDetailModal(self, session, self.session_controller)
 
     def on_previous_month(self) -> None:
         if self.month == 1:

--- a/ui/pages/session_page_components/session_preview.py
+++ b/ui/pages/session_page_components/session_preview.py
@@ -13,9 +13,12 @@ from controllers.session_controller import SessionController
 class SessionPreview(ctk.CTkFrame):
     """Display area for generated session details."""
 
-    def __init__(self, parent, controller: SessionController) -> None:
+    def __init__(
+        self, parent, controller: SessionController, show_action_buttons: bool = True
+    ) -> None:
         super().__init__(parent)
         self.controller = controller
+        self.show_action_buttons = show_action_buttons
         self.grid_rowconfigure(0, weight=1)
         self.grid_columnconfigure(0, weight=1)
 
@@ -85,16 +88,17 @@ class SessionPreview(ctk.CTkFrame):
         self.after(10, self._arrange_blocks)
         self._grid.bind("<Configure>", lambda e: self._arrange_blocks())
 
-        btn_frame = ctk.CTkFrame(self._content, fg_color="transparent")
-        btn_frame.pack(padx=8, pady=12, anchor="e")
-        self._export_btn = PrimaryButton(
-            btn_frame, text="Exporter en PDF", command=self._on_export_pdf
-        )
-        self._export_btn.pack(side="right", padx=(8, 0))
-        self._save_btn = PrimaryButton(
-            btn_frame, text="Enregistrer la séance", command=self._on_save
-        )
-        self._save_btn.pack(side="right")
+        if self.show_action_buttons:
+            btn_frame = ctk.CTkFrame(self._content, fg_color="transparent")
+            btn_frame.pack(padx=8, pady=12, anchor="e")
+            self._export_btn = PrimaryButton(
+                btn_frame, text="Exporter en PDF", command=self._on_export_pdf
+            )
+            self._export_btn.pack(side="right", padx=(8, 0))
+            self._save_btn = PrimaryButton(
+                btn_frame, text="Enregistrer la séance", command=self._on_save
+            )
+            self._save_btn.pack(side="right")
 
     def _arrange_blocks(self) -> None:
         """Place workout blocks in a responsive grid."""


### PR DESCRIPTION
## Summary
- enable fetching full sessions by id
- add session detail modal leveraging existing preview component
- make calendar sessions clickable and open detail modal

## Testing
- `pytest -q` *(fails: no display name and no $DISPLAY environment variable)*

------
https://chatgpt.com/codex/tasks/task_e_68a7871f57e4832aa29a16f80d79c599