### PR TITLE
Implement drag-and-drop session scheduling

### DIFF
--- a/controllers/calendar_controller.py
+++ b/controllers/calendar_controller.py
@@ -25,3 +25,9 @@ class CalendarController:
 
     def get_session_details(self, session_id: str) -> Session | None:
         return self.session_service.get_session_by_id(session_id)
+
+    def get_unscheduled_sessions(self) -> list[Session]:
+        return self.calendar_service.get_unscheduled_sessions()
+
+    def schedule_session(self, session_id: str, year: int, month: int, day: int) -> None:
+        self.calendar_service.schedule_session(session_id, year, month, day)

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -134,6 +134,7 @@ CREATE TABLE sessions (
     label TEXT NOT NULL,
     duration_sec INTEGER NOT NULL,
     date_creation TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    is_template INTEGER NOT NULL DEFAULT 0,
     FOREIGN KEY(client_id) REFERENCES clients(id)
 );
 

--- a/models/session.py
+++ b/models/session.py
@@ -32,5 +32,6 @@ class Session:
     duration_sec: int
     date_creation: str
     client_id: Optional[int] = None
+    is_template: bool = False
     blocks: List[Block] = field(default_factory=list)
     meta: Dict[str, Number | str] = field(default_factory=dict)

--- a/services/calendar_service.py
+++ b/services/calendar_service.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
+import uuid
 from typing import List
 
-from models.session import Session
+from models.session import Block, BlockItem, Session
 from repositories.sessions_repo import SessionsRepository
 
 
@@ -12,3 +13,49 @@ class CalendarService:
 
     def get_sessions_for_month(self, year: int, month: int) -> List[Session]:
         return self.repo.list_sessions_for_month(year, month)
+
+    def get_unscheduled_sessions(self) -> List[Session]:
+        return self.repo.list_templates()
+
+    def schedule_session(self, template_id: str, year: int, month: int, day: int) -> None:
+        template = self.repo.get_by_id(template_id)
+        if not template:
+            return
+        new_session_id = uuid.uuid4().hex
+        new_blocks = []
+        for idx, blk in enumerate(template.blocks, start=1):
+            new_block_id = f"{new_session_id}-b{idx}"
+            items = [
+                BlockItem(
+                    exercise_id=it.exercise_id,
+                    prescription=it.prescription.copy(),
+                    notes=it.notes,
+                )
+                for it in blk.items
+            ]
+            new_blocks.append(
+                Block(
+                    block_id=new_block_id,
+                    type=blk.type,
+                    duration_sec=blk.duration_sec,
+                    rounds=blk.rounds,
+                    work_sec=blk.work_sec,
+                    rest_sec=blk.rest_sec,
+                    items=items,
+                    title=blk.title,
+                    locked=blk.locked,
+                )
+            )
+        date_str = f"{year:04d}-{month:02d}-{day:02d} 12:00:00"
+        new_session = Session(
+            session_id=new_session_id,
+            mode=template.mode,
+            label=template.label,
+            duration_sec=template.duration_sec,
+            date_creation=date_str,
+            client_id=None,
+            is_template=False,
+            blocks=new_blocks,
+            meta={},
+        )
+        self.repo.save(new_session)

--- a/ui/components/draggable_list.py
+++ b/ui/components/draggable_list.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from typing import Callable, List
+
+import customtkinter as ctk
+
+from models.session import Session
+
+
+class DraggableList(ctk.CTkFrame):
+    def __init__(self, parent, on_drag_start: Callable[[str], None]) -> None:
+        super().__init__(parent)
+        self.on_drag_start = on_drag_start
+        self.container = ctk.CTkFrame(self)
+        self.container.pack(fill="both", expand=True)
+
+    def set_sessions(self, sessions: List[Session]) -> None:
+        for w in self.container.winfo_children():
+            w.destroy()
+        for sess in sorted(sessions, key=lambda s: s.label.lower()):
+            btn = ctk.CTkButton(
+                self.container,
+                text=sess.label,
+                anchor="w",
+                fg_color="transparent",
+                hover_color="#333333",
+            )
+            btn.pack(fill="x", pady=2, padx=2)
+            btn.bind("<ButtonPress-1>", lambda e, sid=sess.session_id: self.on_drag_start(sid))


### PR DESCRIPTION
## Summary
- add `is_template` flag to sessions for reusable models
- support listing templates and cloning them when scheduled
- introduce draggable session list and calendar drop zones

## Testing
- `pytest` *(fails: no display name and no $DISPLAY environment variable)*

------
https://chatgpt.com/codex/tasks/task_e_68a789bd4a08832ab0293cc678b6acc2