### PR TITLE
feat: enable session results tracking

### DIFF
--- a/app.py
+++ b/app.py
@@ -7,11 +7,13 @@ from controllers.client_controller import ClientController
 from controllers.dashboard_controller import DashboardController
 from controllers.nutrition_controller import NutritionController
 from controllers.session_controller import SessionController
+from controllers.tracking_controller import TrackingController
 from repositories.aliment_repo import AlimentRepository
 from repositories.client_repo import ClientRepository
 from repositories.exercices_repo import ExerciseRepository
 from repositories.fiche_nutrition_repo import FicheNutritionRepository
 from repositories.plan_alimentaire_repo import PlanAlimentaireRepository
+from repositories.resultat_exercice_repo import ResultatExerciceRepository
 from repositories.sessions_repo import SessionsRepository
 from services.client_service import ClientService
 from services.calendar_service import CalendarService
@@ -20,6 +22,7 @@ from services.exercise_service import ExerciseService
 from services.nutrition_service import NutritionService
 from services.plan_alimentaire_service import PlanAlimentaireService
 from services.session_service import SessionService
+from services.tracking_service import TrackingService
 from ui.layout.app_shell import AppShell
 from ui.pages.billing_page import BillingPage
 from ui.pages.calendar_page import CalendarPage
@@ -71,6 +74,12 @@ class CoachApp(ctk.CTk):
             session_service, client_service, exercise_service
         )
 
+        result_repo = ResultatExerciceRepository()
+        tracking_service = TrackingService(result_repo)
+        self.tracking_controller = TrackingController(
+            tracking_service, session_service, ExerciseRepository()
+        )
+
         calendar_service = CalendarService(sessions_repo)
         self.calendar_controller = CalendarController(
             calendar_service, session_service
@@ -113,6 +122,7 @@ class CoachApp(ctk.CTk):
                     self.shell.content_area,
                     self.calendar_controller,
                     self.session_controller,
+                    self.tracking_controller,
                 )
             case "nutrition":
                 self.current_page = NutritionPage(

--- a/controllers/tracking_controller.py
+++ b/controllers/tracking_controller.py
@@ -1,0 +1,43 @@
+from typing import Any, Dict, List
+
+from repositories.exercices_repo import ExerciseRepository
+from services.session_service import SessionService
+from services.tracking_service import TrackingService
+
+
+class TrackingController:
+    def __init__(
+        self,
+        tracking_service: TrackingService,
+        session_service: SessionService,
+        exercise_repo: ExerciseRepository,
+    ) -> None:
+        self.tracking_service = tracking_service
+        self.session_service = session_service
+        self.exercise_repo = exercise_repo
+
+    def get_session_for_logging(self, session_id: str) -> Dict[str, Any]:
+        session = self.session_service.get_session_by_id(session_id)
+        if not session:
+            return {"session": None, "exercises": []}
+        exercise_ids: List[int] = []
+        for blk in session.blocks:
+            for it in blk.items:
+                eid = int(it.exercise_id)
+                if eid not in exercise_ids:
+                    exercise_ids.append(eid)
+        names = self.exercise_repo.get_names_by_ids(exercise_ids)
+        existing = self.tracking_service.get_results_for_session(session_id)
+        exercises = []
+        for eid in exercise_ids:
+            exercises.append(
+                {
+                    "id": eid,
+                    "name": names.get(eid, f"Exercice {eid}"),
+                    "result": existing.get(eid, {}),
+                }
+            )
+        return {"session": session, "exercises": exercises}
+
+    def save_session_results(self, session_id: str, results_data: List[Dict[str, Any]]) -> None:
+        self.tracking_service.save_session_results(session_id, results_data)

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -50,14 +50,16 @@ CREATE TABLE seances (
 
 CREATE TABLE resultats_exercices (
     id INTEGER PRIMARY KEY,
-    seance_id INTEGER NOT NULL,
+    session_id TEXT NOT NULL,
     exercice_id INTEGER NOT NULL,
     series_effectuees INTEGER,
     reps_effectuees INTEGER,
     charge_utilisee REAL,
+    rpe INTEGER,
     feedback_client TEXT,
-    FOREIGN KEY(seance_id) REFERENCES seances(id),
-    FOREIGN KEY(exercice_id) REFERENCES exercices(id)
+    FOREIGN KEY(session_id) REFERENCES sessions(session_id),
+    FOREIGN KEY(exercice_id) REFERENCES exercices(id),
+    UNIQUE(session_id, exercice_id)
 );
 
 CREATE TABLE aliments (

--- a/models/resultat_exercice.py
+++ b/models/resultat_exercice.py
@@ -5,9 +5,10 @@ from typing import Optional
 @dataclass
 class ResultatExercice:
     id: int
-    seance_id: int
+    session_id: str
     exercice_id: int
     series_effectuees: Optional[int] = None
     reps_effectuees: Optional[int] = None
     charge_utilisee: Optional[float] = None
+    rpe: Optional[int] = None
     feedback_client: Optional[str] = None

--- a/repositories/resultat_exercice_repo.py
+++ b/repositories/resultat_exercice_repo.py
@@ -1,0 +1,47 @@
+from typing import Any, Dict
+
+from db.database_manager import db_manager
+
+
+class ResultatExerciceRepository:
+    """Interact with the ``resultats_exercices`` table."""
+
+    def upsert(
+        self,
+        session_id: str,
+        exercice_id: int,
+        poids: float | None,
+        repetitions: int | None,
+        rpe: int | None,
+        series_effectuees: int | None,
+    ) -> None:
+        with db_manager.get_connection() as conn:
+            conn.execute(
+                """
+                INSERT INTO resultats_exercices (
+                    session_id, exercice_id, charge_utilisee, reps_effectuees, rpe, series_effectuees
+                ) VALUES (?,?,?,?,?,?)
+                ON CONFLICT(session_id, exercice_id) DO UPDATE SET
+                    charge_utilisee=excluded.charge_utilisee,
+                    reps_effectuees=excluded.reps_effectuees,
+                    rpe=excluded.rpe,
+                    series_effectuees=excluded.series_effectuees
+                """,
+                (session_id, exercice_id, poids, repetitions, rpe, series_effectuees),
+            )
+
+    def get_results_for_session(self, session_id: str) -> Dict[int, Dict[str, Any]]:
+        with db_manager.get_connection() as conn:
+            rows = conn.execute(
+                "SELECT * FROM resultats_exercices WHERE session_id = ?",
+                (session_id,),
+            ).fetchall()
+        out: Dict[int, Dict[str, Any]] = {}
+        for r in rows:
+            out[r["exercice_id"]] = {
+                "poids": r["charge_utilisee"],
+                "repetitions": r["reps_effectuees"],
+                "rpe": r["rpe"],
+                "series_effectuees": r["series_effectuees"],
+            }
+        return out

--- a/services/tracking_service.py
+++ b/services/tracking_service.py
@@ -1,0 +1,22 @@
+from typing import Any, Dict, List
+
+from repositories.resultat_exercice_repo import ResultatExerciceRepository
+
+
+class TrackingService:
+    def __init__(self, repo: ResultatExerciceRepository) -> None:
+        self.repo = repo
+
+    def save_session_results(self, session_id: str, results_data: List[Dict[str, Any]]) -> None:
+        for res in results_data:
+            self.repo.upsert(
+                session_id=session_id,
+                exercice_id=int(res.get("exercise_id")),
+                poids=res.get("poids"),
+                repetitions=res.get("repetitions"),
+                rpe=res.get("rpe"),
+                series_effectuees=res.get("series_effectuees"),
+            )
+
+    def get_results_for_session(self, session_id: str) -> Dict[int, Dict[str, Any]]:
+        return self.repo.get_results_for_session(session_id)

--- a/ui/components/calendar_view.py
+++ b/ui/components/calendar_view.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import calendar
+from datetime import date
 from typing import Callable, Dict, List
 
 import customtkinter as ctk
@@ -34,11 +35,13 @@ class CalendarView(ctk.CTkFrame):
         on_session_click: Callable[[str], None] | None = None,
         get_dragged_session_id: Callable[[], str | None] | None = None,
         on_session_drop: Callable[[str, int, int, int], None] | None = None,
+        on_log_session: Callable[[str], None] | None = None,
     ) -> None:
         super().__init__(parent)
         self.on_session_click = on_session_click
         self.get_dragged_session_id = get_dragged_session_id
         self.on_session_drop = on_session_drop
+        self.on_log_session = on_log_session
 
         header = ctk.CTkFrame(self)
         header.pack(fill="x", pady=5)
@@ -90,14 +93,24 @@ class CalendarView(ctk.CTkFrame):
                 cell.bind("<ButtonRelease-1>", lambda e, d=day: self._handle_drop(d))
                 ctk.CTkLabel(cell, text=str(day)).pack(anchor="ne", padx=2, pady=2)
                 for sess in data.get(day, []):
+                    row = ctk.CTkFrame(cell, fg_color="transparent")
+                    row.pack(anchor="w", padx=2, pady=1, fill="x")
                     ctk.CTkButton(
-                        cell,
+                        row,
                         text=sess.label,
                         anchor="w",
                         command=lambda sid=sess.session_id: self._handle_session_click(
                             sid
                         ),
-                    ).pack(anchor="w", padx=2)
+                    ).pack(side="left", fill="x", expand=True)
+                    sess_date = date(year, month, day)
+                    if self.on_log_session and sess_date <= date.today():
+                        ctk.CTkButton(
+                            row,
+                            text="+",
+                            width=20,
+                            command=lambda sid=sess.session_id: self.on_log_session(sid),
+                        ).pack(side="left", padx=2)
 
     def _handle_session_click(self, session_id: str) -> None:
         if self.on_session_click:

--- a/ui/modals/session_log_modal.py
+++ b/ui/modals/session_log_modal.py
@@ -1,149 +1,106 @@
-from typing import Callable, Dict, List
+from __future__ import annotations
+
+from typing import Any, Dict, List
 
 import customtkinter as ctk
 
-from models.resultat_exercice import ResultatExercice
-from models.seance import Seance
-from repositories.exercices_repo import ExerciseRepository
-from repositories.seance_repo import SeanceRepository
-from ui.theme.colors import DARK_BG
+from controllers.tracking_controller import TrackingController
+from ui.modals.base_modal import BaseFormModal
 
 
-class SessionLogModal(ctk.CTkToplevel):
-    def __init__(
-        self, parent, client_id: int, on_saved: Callable[[], None] | None = None
-    ):
-        super().__init__(parent)
-        self.client_id = client_id
-        self.on_saved = on_saved
-        self.seance_repo = SeanceRepository()
-        self.exercise_repo = ExerciseRepository()
+class _ExercisesResultsField(ctk.CTkScrollableFrame):
+    """Custom field listing exercises with inputs for results."""
 
-        self.title("Enregistrer une séance")
-        self.geometry("500x600")
-        self.configure(fg_color=DARK_BG)
-        self.resizable(False, False)
-
-        self.title_var = ctk.StringVar()
-        self.date_var = ctk.StringVar()
-
-        self._build_form()
-        self.exercise_entries: List[Dict] = []
-
-    def _build_form(self):
-        general = ctk.CTkFrame(self, fg_color="transparent")
-        general.pack(fill="x", padx=20, pady=(20, 10))
-
-        ctk.CTkLabel(general, text="Titre de la séance").pack(anchor="w")
-        ctk.CTkEntry(general, textvariable=self.title_var).pack(fill="x", pady=5)
-
-        ctk.CTkLabel(general, text="Date (AAAA-MM-JJ)").pack(anchor="w")
-        ctk.CTkEntry(general, textvariable=self.date_var).pack(fill="x", pady=5)
-
-        ex_container = ctk.CTkFrame(self, fg_color="transparent")
-        ex_container.pack(fill="both", expand=True, padx=20, pady=10)
-
-        add_frame = ctk.CTkFrame(ex_container, fg_color="transparent")
-        add_frame.pack(fill="x")
-
-        exercices = self.exercise_repo.list_all_exercices()
-        self.ex_map = {e.nom: e.id for e in exercices}
-        values = list(self.ex_map.keys()) if self.ex_map else [""]
-        self.option_var = ctk.StringVar(value=values[0] if values else "")
-        ctk.CTkOptionMenu(add_frame, variable=self.option_var, values=values).pack(
-            side="left", padx=(0, 10)
-        )
-        ctk.CTkButton(
-            add_frame, text="Ajouter un exercice", command=self._add_exercise
-        ).pack(side="left")
-
-        self.ex_scroll = ctk.CTkScrollableFrame(ex_container, fg_color="transparent")
-        self.ex_scroll.pack(fill="both", expand=True, pady=(10, 0))
-
-        action = ctk.CTkFrame(self, fg_color="transparent")
-        action.pack(pady=10)
-        ctk.CTkButton(action, text="Enregistrer la séance", command=self._save).pack(
-            side="left", padx=5
-        )
-        ctk.CTkButton(action, text="Annuler", command=self.destroy).pack(
-            side="left", padx=5
-        )
-
-    def _add_exercise(self):
-        name = self.option_var.get()
-        if not name:
-            return
-        ex_id = self.ex_map[name]
-        frame = ctk.CTkFrame(self.ex_scroll)
-        frame.pack(fill="x", pady=5, padx=5)
-
-        ctk.CTkLabel(frame, text=name, width=150).grid(row=0, column=0, padx=5)
-        series_var = ctk.StringVar()
-        reps_var = ctk.StringVar()
-        charge_var = ctk.StringVar()
-        ctk.CTkEntry(
-            frame, width=40, textvariable=series_var, placeholder_text="Séries"
-        ).grid(row=0, column=1, padx=5)
-        ctk.CTkEntry(
-            frame, width=40, textvariable=reps_var, placeholder_text="Reps"
-        ).grid(row=0, column=2, padx=5)
-        ctk.CTkEntry(
-            frame, width=60, textvariable=charge_var, placeholder_text="Charge"
-        ).grid(row=0, column=3, padx=5)
-        ctk.CTkButton(
-            frame, text="X", width=20, command=lambda: self._remove_exercise(frame)
-        ).grid(row=0, column=4, padx=5)
-
-        self.exercise_entries.append(
-            {
-                "id": ex_id,
-                "series": series_var,
-                "reps": reps_var,
-                "charge": charge_var,
-                "frame": frame,
-            }
-        )
-
-    def _remove_exercise(self, frame):
-        for entry in list(self.exercise_entries):
-            if entry["frame"] is frame:
-                entry["frame"].destroy()
-                self.exercise_entries.remove(entry)
-                break
-
-    def _save(self):
-        seance = Seance(
-            id=0,
-            client_id=self.client_id,
-            type_seance="manuel",
-            titre=self.title_var.get(),
-            date_creation=self.date_var.get(),
-        )
-        resultats: List[ResultatExercice] = []
-        for e in self.exercise_entries:
-            try:
-                series = int(e["series"].get()) if e["series"].get() else None
-            except ValueError:
-                series = None
-            try:
-                reps = int(e["reps"].get()) if e["reps"].get() else None
-            except ValueError:
-                reps = None
-            try:
-                charge = float(e["charge"].get()) if e["charge"].get() else None
-            except ValueError:
-                charge = None
-            resultats.append(
-                ResultatExercice(
-                    id=0,
-                    seance_id=0,
-                    exercice_id=e["id"],
-                    series_effectuees=series,
-                    reps_effectuees=reps,
-                    charge_utilisee=charge,
-                )
+    def __init__(self, master, exercises: List[Dict[str, Any]]):
+        super().__init__(master, fg_color="transparent")
+        self.entries: List[Dict[str, Any]] = []
+        for ex in exercises:
+            row = ctk.CTkFrame(self, fg_color="transparent")
+            row.pack(fill="x", pady=5)
+            ctk.CTkLabel(row, text=ex["name"], width=150, anchor="w").pack(
+                side="left", padx=(0, 10)
             )
-        self.seance_repo.add_seance(seance, resultats)
-        if self.on_saved:
-            self.on_saved()
-        self.destroy()
+            poids = ctk.CTkEntry(row, width=60, placeholder_text="Poids")
+            poids.pack(side="left", padx=5)
+            reps = ctk.CTkEntry(row, width=60, placeholder_text="Répétitions")
+            reps.pack(side="left", padx=5)
+            rpe = ctk.CTkEntry(row, width=40, placeholder_text="RPE")
+            rpe.pack(side="left", padx=5)
+            series = ctk.CTkEntry(row, width=40, placeholder_text="Séries")
+            series.pack(side="left", padx=5)
+
+            res = ex.get("result", {})
+            if res.get("poids") is not None:
+                poids.insert(0, str(res["poids"]))
+            if res.get("repetitions") is not None:
+                reps.insert(0, str(res["repetitions"]))
+            if res.get("rpe") is not None:
+                rpe.insert(0, str(res["rpe"]))
+            if res.get("series_effectuees") is not None:
+                series.insert(0, str(res["series_effectuees"]))
+
+            self.entries.append(
+                {
+                    "exercise_id": ex["id"],
+                    "poids": poids,
+                    "repetitions": reps,
+                    "rpe": rpe,
+                    "series": series,
+                }
+            )
+
+    # Methods expected by BaseFormModal
+    def get_value(self) -> List[Dict[str, Any]]:  # type: ignore[override]
+        out: List[Dict[str, Any]] = []
+        for item in self.entries:
+            def _parse(entry, typ):
+                value = entry.get().strip()
+                if not value:
+                    return None
+                try:
+                    return typ(value)
+                except ValueError:
+                    return None
+
+            out.append(
+                {
+                    "exercise_id": item["exercise_id"],
+                    "poids": _parse(item["poids"], float),
+                    "repetitions": _parse(item["repetitions"], int),
+                    "rpe": _parse(item["rpe"], int),
+                    "series_effectuees": _parse(item["series"], int),
+                }
+            )
+        return out
+
+    def set_value(self, value: Any) -> None:  # type: ignore[override]
+        pass
+
+    def show_error(self, message: str) -> None:  # type: ignore[override]
+        pass
+
+    def hide_error(self) -> None:  # type: ignore[override]
+        pass
+
+
+class SessionLogModal(BaseFormModal):
+    def __init__(
+        self, parent, session_id: str, tracking_controller: TrackingController
+    ) -> None:
+        self.session_id = session_id
+        self.controller = tracking_controller
+        data = self.controller.get_session_for_logging(session_id)
+        session = data.get("session")
+        exercises = data.get("exercises", [])
+        title = f"Résultats – {session.label}" if session else "Résultats"
+        super().__init__(
+            parent,
+            title=title,
+            form_fields={"results": lambda master: _ExercisesResultsField(master, exercises)},
+            save_callback=self._on_save,
+        )
+        self.geometry("600x400")
+
+    def _on_save(self, form_data: Dict[str, Any]) -> None:
+        results = form_data.get("results", [])
+        self.controller.save_session_results(self.session_id, results)

--- a/ui/pages/calendar_page.py
+++ b/ui/pages/calendar_page.py
@@ -5,9 +5,11 @@ import customtkinter as ctk
 
 from controllers.calendar_controller import CalendarController
 from controllers.session_controller import SessionController
+from controllers.tracking_controller import TrackingController
 from ui.components.calendar_view import CalendarView
 from ui.components.draggable_list import DraggableList
 from ui.modals.session_detail_modal import SessionDetailModal
+from ui.modals.session_log_modal import SessionLogModal
 from ui.theme.fonts import get_section_font
 
 
@@ -17,10 +19,12 @@ class CalendarPage(ctk.CTkFrame):
         parent,
         controller: CalendarController,
         session_controller: SessionController,
+        tracking_controller: TrackingController,
     ):
         super().__init__(parent)
         self.controller = controller
         self.session_controller = session_controller
+        self.tracking_controller = tracking_controller
         today = datetime.date.today()
         self.year = today.year
         self.month = today.month
@@ -47,6 +51,7 @@ class CalendarPage(ctk.CTkFrame):
             self.on_session_click,
             self.get_dragged_session_id,
             self.on_session_drop,
+            self.on_log_session,
         )
         self.calendar.pack(fill="both", expand=True)
         self._refresh()
@@ -72,6 +77,9 @@ class CalendarPage(ctk.CTkFrame):
         session = self.controller.get_session_details(session_id)
         if session:
             SessionDetailModal(self, session, self.session_controller)
+
+    def on_log_session(self, session_id: str) -> None:
+        SessionLogModal(self, session_id, self.tracking_controller)
 
     def on_previous_month(self) -> None:
         if self.month == 1:


### PR DESCRIPTION
Résumé : Cette PR introduit la première brique du suivi de progression : la saisie des résultats de séance. Une nouvelle couche de service et de contrôleur (Tracking) a été créée. La modale de saisie a été refactorisée et est maintenant accessible depuis le calendrier, permettant au coach d'enregistrer les performances de ses clients.

------
https://chatgpt.com/codex/tasks/task_e_68a78eb631b4832a890027c80ca4b404