### PR TITLE
feat: add exercise progression charts

### DIFF
--- a/controllers/tracking_controller.py
+++ b/controllers/tracking_controller.py
@@ -3,6 +3,7 @@ from typing import Any, Dict, List
 from repositories.exercices_repo import ExerciseRepository
 from services.session_service import SessionService
 from services.tracking_service import TrackingService
+from dtos.tracking_dtos import ExerciseProgressionDTO, TrackedExerciseDTO
 
 
 class TrackingController:
@@ -41,3 +42,11 @@ class TrackingController:
 
     def save_session_results(self, session_id: str, results_data: List[Dict[str, Any]]) -> None:
         self.tracking_service.save_session_results(session_id, results_data)
+
+    def get_exercise_progression(
+        self, client_id: int, exercice_id: int
+    ) -> ExerciseProgressionDTO:
+        return self.tracking_service.get_exercise_progression(client_id, exercice_id)
+
+    def get_tracked_exercises(self, client_id: int) -> List[TrackedExerciseDTO]:
+        return self.tracking_service.get_tracked_exercises(client_id)

--- a/dtos/tracking_dtos.py
+++ b/dtos/tracking_dtos.py
@@ -1,0 +1,15 @@
+from dataclasses import dataclass
+
+
+@dataclass
+class TrackedExerciseDTO:
+    id: int
+    name: str
+
+
+@dataclass
+class ExerciseProgressionDTO:
+    dates: list[str]
+    poids: list[float]
+    repetitions: list[int]
+    rpe: list[int]

--- a/models/resultat_exercice.py
+++ b/models/resultat_exercice.py
@@ -7,6 +7,7 @@ class ResultatExercice:
     id: int
     session_id: str
     exercice_id: int
+    session_date: str | None = None
     series_effectuees: Optional[int] = None
     reps_effectuees: Optional[int] = None
     charge_utilisee: Optional[float] = None

--- a/repositories/resultat_exercice_repo.py
+++ b/repositories/resultat_exercice_repo.py
@@ -1,6 +1,7 @@
-from typing import Any, Dict
+from typing import Any, Dict, List, Tuple
 
 from db.database_manager import db_manager
+from models.resultat_exercice import ResultatExercice
 
 
 class ResultatExerciceRepository:
@@ -45,3 +46,49 @@ class ResultatExerciceRepository:
                 "series_effectuees": r["series_effectuees"],
             }
         return out
+
+    def get_results_for_exercise(
+        self, client_id: int, exercice_id: int
+    ) -> List[ResultatExercice]:
+        with db_manager.get_connection() as conn:
+            rows = conn.execute(
+                """
+                SELECT r.id, r.session_id, r.exercice_id, r.series_effectuees,
+                       r.reps_effectuees, r.charge_utilisee, r.rpe,
+                       r.feedback_client, s.date_creation
+                FROM resultats_exercices r
+                JOIN sessions s ON r.session_id = s.session_id
+                WHERE s.client_id = ? AND r.exercice_id = ?
+                ORDER BY s.date_creation
+                """,
+                (client_id, exercice_id),
+            ).fetchall()
+        return [
+            ResultatExercice(
+                id=row["id"],
+                session_id=row["session_id"],
+                exercice_id=row["exercice_id"],
+                session_date=row["date_creation"],
+                series_effectuees=row["series_effectuees"],
+                reps_effectuees=row["reps_effectuees"],
+                charge_utilisee=row["charge_utilisee"],
+                rpe=row["rpe"],
+                feedback_client=row["feedback_client"],
+            )
+            for row in rows
+        ]
+
+    def get_tracked_exercises(self, client_id: int) -> List[Tuple[int, str]]:
+        with db_manager.get_connection() as conn:
+            rows = conn.execute(
+                """
+                SELECT DISTINCT e.id, e.nom
+                FROM resultats_exercices r
+                JOIN sessions s ON r.session_id = s.session_id
+                JOIN exercices e ON r.exercice_id = e.id
+                WHERE s.client_id = ?
+                ORDER BY e.nom
+                """,
+                (client_id,),
+            ).fetchall()
+        return [(row["id"], row["nom"]) for row in rows]

--- a/services/tracking_service.py
+++ b/services/tracking_service.py
@@ -1,6 +1,7 @@
 from typing import Any, Dict, List
 
 from repositories.resultat_exercice_repo import ResultatExerciceRepository
+from dtos.tracking_dtos import ExerciseProgressionDTO, TrackedExerciseDTO
 
 
 class TrackingService:
@@ -20,3 +21,18 @@ class TrackingService:
 
     def get_results_for_session(self, session_id: str) -> Dict[int, Dict[str, Any]]:
         return self.repo.get_results_for_session(session_id)
+
+    def get_exercise_progression(
+        self, client_id: int, exercice_id: int
+    ) -> ExerciseProgressionDTO:
+        results = self.repo.get_results_for_exercise(client_id, exercice_id)
+        return ExerciseProgressionDTO(
+            dates=[r.session_date or "" for r in results],
+            poids=[r.charge_utilisee or 0 for r in results],
+            repetitions=[r.reps_effectuees or 0 for r in results],
+            rpe=[r.rpe or 0 for r in results],
+        )
+
+    def get_tracked_exercises(self, client_id: int) -> List[TrackedExerciseDTO]:
+        rows = self.repo.get_tracked_exercises(client_id)
+        return [TrackedExerciseDTO(id=r[0], name=r[1]) for r in rows]

--- a/ui/components/charts/line_chart.py
+++ b/ui/components/charts/line_chart.py
@@ -1,0 +1,33 @@
+import customtkinter as ctk
+from matplotlib.backends.backend_tkagg import FigureCanvasTkAgg
+from matplotlib.figure import Figure
+
+from ui.theme.colors import DARK_BG, DARK_PANEL, PRIMARY, TEXT
+
+
+class LineChart(ctk.CTkFrame):
+    def __init__(
+        self,
+        master,
+        dates: list[str],
+        values: list[float],
+        title: str = "",
+        xlabel: str = "",
+        ylabel: str = "",
+    ) -> None:
+        super().__init__(master, fg_color=DARK_PANEL)
+        fig = Figure(figsize=(5, 4), dpi=100)
+        fig.patch.set_facecolor(DARK_PANEL)
+        ax = fig.add_subplot(111)
+        ax.set_facecolor(DARK_BG)
+        ax.plot(dates, values, color=PRIMARY, marker="o")
+        ax.set_title(title, color=TEXT)
+        ax.set_xlabel(xlabel, color=TEXT)
+        ax.set_ylabel(ylabel, color=TEXT)
+        ax.tick_params(axis="x", colors=TEXT, rotation=45)
+        ax.tick_params(axis="y", colors=TEXT)
+        for spine in ax.spines.values():
+            spine.set_color(TEXT)
+        self.canvas = FigureCanvasTkAgg(fig, master=self)
+        self.canvas.draw()
+        self.canvas.get_tk_widget().pack(fill="both", expand=True)

--- a/ui/pages/client_detail_page_components/stats_tab.py
+++ b/ui/pages/client_detail_page_components/stats_tab.py
@@ -1,19 +1,25 @@
 import customtkinter as ctk
-from matplotlib.backends.backend_tkagg import FigureCanvasTkAgg
-from matplotlib.figure import Figure
 
+from controllers.tracking_controller import TrackingController
 from repositories.exercices_repo import ExerciseRepository
-from repositories.seance_repo import SeanceRepository
-from ui.theme.colors import DARK_BG, DARK_PANEL, PRIMARY, TEXT
+from repositories.resultat_exercice_repo import ResultatExerciceRepository
+from repositories.sessions_repo import SessionsRepository
+from services.session_service import SessionService
+from services.tracking_service import TrackingService
+from ui.components.charts.line_chart import LineChart
+from ui.theme.colors import DARK_PANEL, PRIMARY, TEXT
 
 
 class StatsTab(ctk.CTkFrame):
     def __init__(self, master, client_id: int):
         super().__init__(master, fg_color="transparent")
         self.client_id = client_id
-        self.seance_repo = SeanceRepository()
-        self.exercice_repo = ExerciseRepository()
-        self.canvas: FigureCanvasTkAgg | None = None
+        self.tracking_controller = TrackingController(
+            TrackingService(ResultatExerciceRepository()),
+            SessionService(SessionsRepository()),
+            ExerciseRepository(),
+        )
+        self.chart: LineChart | None = None
 
         control = ctk.CTkFrame(self, fg_color="transparent")
         control.pack(fill="x", padx=10, pady=10)
@@ -24,10 +30,10 @@ class StatsTab(ctk.CTkFrame):
             text_color=TEXT,
         ).pack(anchor="w")
 
-        exercices = self.exercice_repo.list_all_exercices()
-        self.ex_options = {ex.nom: ex.id for ex in exercices}
+        tracked = self.tracking_controller.get_tracked_exercises(self.client_id)
+        self.ex_options = {ex.name: ex.id for ex in tracked}
         self.var = ctk.StringVar(value="Sélectionner un exercice")
-        ctk.CTkOptionMenu(
+        ctk.CTkComboBox(
             control,
             values=list(self.ex_options.keys()),
             variable=self.var,
@@ -36,6 +42,7 @@ class StatsTab(ctk.CTkFrame):
             button_color=DARK_PANEL,
             button_hover_color=PRIMARY,
             text_color=TEXT,
+            state="readonly",
         ).pack(anchor="w", pady=(5, 0))
 
         self.graph_frame = ctk.CTkFrame(self, fg_color=DARK_PANEL)
@@ -46,9 +53,9 @@ class StatsTab(ctk.CTkFrame):
         )
 
     def _clear_graph(self) -> None:
-        if self.canvas:
-            self.canvas.get_tk_widget().destroy()
-            self.canvas = None
+        if self.chart:
+            self.chart.destroy()
+            self.chart = None
         for w in self.graph_frame.winfo_children():
             w.destroy()
 
@@ -64,28 +71,20 @@ class StatsTab(ctk.CTkFrame):
             )
             return
 
-        history = self.seance_repo.get_exercice_history(self.client_id, ex_id)
-        if not history:
+        progression = self.tracking_controller.get_exercise_progression(
+            self.client_id, ex_id
+        )
+        if not progression.dates:
             self._show_message("Aucune donnée disponible pour cet exercice")
             return
 
         self._clear_graph()
-        dates = [h["date"] for h in history]
-        charges = [h["max_charge"] for h in history]
-
-        fig = Figure(figsize=(5, 4), dpi=100)
-        fig.patch.set_facecolor(DARK_PANEL)
-        ax = fig.add_subplot(111)
-        ax.set_facecolor(DARK_BG)
-        ax.plot(dates, charges, color=PRIMARY, marker="o")
-        ax.set_title(f"Évolution de la charge - {choice}", color=TEXT)
-        ax.set_xlabel("Date de séance", color=TEXT)
-        ax.set_ylabel("Charge max (kg)", color=TEXT)
-        ax.tick_params(axis="x", colors=TEXT, rotation=45)
-        ax.tick_params(axis="y", colors=TEXT)
-        for spine in ax.spines.values():
-            spine.set_color(TEXT)
-
-        self.canvas = FigureCanvasTkAgg(fig, master=self.graph_frame)
-        self.canvas.draw()
-        self.canvas.get_tk_widget().pack(fill="both", expand=True)
+        self.chart = LineChart(
+            self.graph_frame,
+            progression.dates,
+            progression.poids,
+            title=f"Évolution de la charge - {choice}",
+            xlabel="Date de séance",
+            ylabel="Charge (kg)",
+        )
+        self.chart.pack(fill="both", expand=True)


### PR DESCRIPTION
## Summary
- add session date to ResultatExercice and expose exercise history & tracked exercises
- provide tracking service/controller APIs for progression and tracked exercise list
- add reusable matplotlib LineChart component and refactor stats tab to show dynamic charts

## Testing
- `pytest` *(fails: no display name and no $DISPLAY environment variable)*

------
https://chatgpt.com/codex/tasks/task_e_68a83db7bff4832ab64227d7b8e91deb