### PR TITLE
feat: add reusable DataTable with sorting and filtering

### DIFF
--- a/ui/pages/database_page_tabs/aliments_tab.py
+++ b/ui/pages/database_page_tabs/aliments_tab.py
@@ -12,13 +12,9 @@ class AlimentsTab(ctk.CTkFrame):
         super().__init__(parent, fg_color="transparent")
         self.repo = repo or AlimentRepository()
 
-        self.search_var = ctk.StringVar()
-        self.search_var.trace_add("write", self._on_search)
-
-        search_entry = ctk.CTkEntry(
-            self, textvariable=self.search_var, placeholder_text="Rechercher..."
-        )
+        search_entry = ctk.CTkEntry(self, placeholder_text="Rechercher...")
         search_entry.pack(fill="x", padx=10, pady=10)
+        search_entry.bind("<KeyRelease>", self._on_search)
 
         self.aliments: List[Aliment] = self.repo.list_all()
         data = [
@@ -35,5 +31,5 @@ class AlimentsTab(ctk.CTkFrame):
         self.table = DataTable(self, headers=headers, data=data)
         self.table.pack(fill="both", expand=True, padx=10, pady=(0, 10))
 
-    def _on_search(self, *_):
-        self.table.filter(self.search_var.get())
+    def _on_search(self, event):
+        self.table.filter(event.widget.get())

--- a/ui/theme/theme.json
+++ b/ui/theme/theme.json
@@ -76,5 +76,13 @@
     "macOS": { "family": "Inter", "size": 13, "weight": "normal" },
     "Windows": { "family": "Inter", "size": 13, "weight": "normal" },
     "Linux": { "family": "Inter", "size": 13, "weight": "normal" }
+  },
+  "DataTable": {
+    "header_fg_color": "#374151",
+    "header_text_color": "#E5E7EB",
+    "row_even_fg_color": "#1F2937",
+    "row_odd_fg_color": "#212E42",
+    "row_hover_fg_color": "#374151",
+    "row_text_color": "#E5E7EB"
   }
 }


### PR DESCRIPTION
### Résumé
- introduit un composant `DataTable` réutilisable avec tri, filtrage et survol des lignes
- ajoute les couleurs spécifiques à `DataTable` dans le thème
- refactorise l'onglet "Aliments" pour utiliser `DataTable`

### Risques
- Aucun, amélioration UI


------
https://chatgpt.com/codex/tasks/task_e_68a8e0134da0832a96c0e7291e91aaa9