### PR TITLE
Use FormCollectifV2 and extend session params

### DIFF
--- a/controllers/session_controller.py
+++ b/controllers/session_controller.py
@@ -53,10 +53,17 @@ def generate_session_preview(
     """Generate a session and its preview DTO."""
     if mode == "collectif":
         svc_params = {
-            "course_type": params.get("course_type"),
             "duration": int(params.get("duration", 0)),
-            "intensity": params.get("intensity"),
             "equipment": params.get("equipment", []),
+            "variability": int(params.get("variability", 0)),
+            "volume": int(params.get("volume", 0)),
+            "enabled_formats": params.get("formats", []),
+            "continuum": int(params.get("continuum", 0)),
+            "focus": params.get("focus"),
+            "objective": params.get("objective"),
+            "auto_include": params.get("auto_include", []),
+            "course_type": params.get("course_type", "Cross-Training"),
+            "intensity": params.get("intensity", "Moyenne"),
         }
         session = generate_collectif(svc_params)
         ids = [it.exercise_id for b in session.blocks for it in b.items]

--- a/services/session_generator.py
+++ b/services/session_generator.py
@@ -144,7 +144,17 @@ def adjust_to_time_budget(blocks: List[Block], duration_min: int) -> List[Block]
 
 
 def generate_collectif(params: Dict[str, Any]) -> Session:
+    """Generate a collective session from form parameters."""
     params = params.copy()
+    params.setdefault("variability", 50)
+    params.setdefault("volume", 50)
+    params.setdefault("enabled_formats", params.pop("formats", []))
+    params.setdefault("continuum", 0)
+    params.setdefault("focus", "Full-body")
+    params.setdefault("objective", "Force")
+    params.setdefault("auto_include", [])
+    params.setdefault("course_type", "Cross-Training")
+    params.setdefault("intensity", "Moyenne")
     params["duration_min"] = int(
         params.get("duration") or params.get("duration_min", 0)
     )

--- a/ui/pages/session_page.py
+++ b/ui/pages/session_page.py
@@ -6,8 +6,11 @@ from controllers import session_controller
 from repositories.client_repo import ClientRepository
 from services.client_service import ClientService
 from ui.components.design_system.typography import PageTitle
+from ui.components.layout import two_columns
 
-from .session_page_components.form_collectif_v2 import FormCollectif
+from .session_page_components.form_collectif_v2 import (
+    FormCollectif as FormCollectifV2,
+)
 from .session_page_components.form_individuel import FormIndividuel
 from .session_page_components.session_preview import SessionPreview
 
@@ -18,20 +21,25 @@ class SessionPage(ctk.CTkFrame):
     def __init__(self, parent):
         super().__init__(parent)
         self.grid_rowconfigure(1, weight=1)
-        self.grid_columnconfigure((0, 1), weight=1)
 
         PageTitle(self, text="Séances").grid(
             row=0, column=0, columnspan=2, sticky="w", padx=16, pady=(16, 8)
         )
 
+        container = ctk.CTkFrame(self, fg_color="transparent")
+        container.grid(row=1, column=0, columnspan=2, sticky="nsew")
+        left_col, right_col = two_columns(container)
+        left_col.grid(row=0, column=0, sticky="nsew")
+        right_col.grid(row=0, column=1, sticky="nsew")
+
         # Onglets pour les formulaires
-        tabs = ctk.CTkTabview(self)
-        tabs.grid(row=1, column=0, sticky="nsew", padx=(16, 8), pady=16)
+        tabs = ctk.CTkTabview(left_col)
+        tabs.pack(fill="both", expand=True, padx=16, pady=16)
 
         collectif_tab = tabs.add("Cours Collectif")
         individuel_tab = tabs.add("Individuel")
 
-        self.form_collectif = FormCollectif(
+        self.form_collectif = FormCollectifV2(
             collectif_tab, generate_callback=self.on_generate_collectif
         )
         self.form_collectif.pack(fill="both", expand=True, padx=16, pady=16)
@@ -41,8 +49,8 @@ class SessionPage(ctk.CTkFrame):
         self.form_individuel.pack(fill="both", expand=True, padx=16, pady=16)
 
         # Aperçu de la séance
-        self.preview_panel = SessionPreview(self)
-        self.preview_panel.grid(row=1, column=1, sticky="nsew", padx=(8, 16), pady=16)
+        self.preview_panel = SessionPreview(right_col)
+        self.preview_panel.pack(fill="both", expand=True, padx=16, pady=16)
 
     def on_generate_collectif(self) -> None:
         params = self.form_collectif.get_params()


### PR DESCRIPTION
## Summary
- Switch session page to `FormCollectifV2` with new two-column layout for persistent preview
- Pass extended form parameters through controller to `generate_collectif`
- Accept additional parameters in `generate_collectif` service with sensible defaults

## Testing
- `pytest -q` *(fails: no display name and no $DISPLAY environment variable)*

------
https://chatgpt.com/codex/tasks/task_e_68b1ddeba9cc832a8206048048be5b6d