### PR TITLE
Add CTkButton border color to theme

### DIFF
--- a/ui/theme/theme.json
+++ b/ui/theme/theme.json
@@ -30,6 +30,7 @@
   "CTkButton": {
     "corner_radius": 6,
     "border_width": 0,
+    "border_color": ["#374151", "#374151"],
     "fg_color": ["#22D3EE", "#22D3EE"],
     "hover_color": ["#06B6D4", "#06B6D4"],
     "text_color": ["#111827", "#111827"],


### PR DESCRIPTION
## Summary
- set `CTkButton` border color in theme to match palette

## Testing
- `xvfb-run -a python test_startup.py` *(fails: no such table: clients)*

------
https://chatgpt.com/codex/tasks/task_e_68b1f7974320832a861776647e89a652