### PR TITLE
Refactor to reuse ExerciseRepository in app setup

### DIFF
--- a/app.py
+++ b/app.py
@@ -72,7 +72,8 @@ class CoachApp(ctk.CTk):
         )
 
         session_service = SessionService(sessions_repo)
-        exercise_service = ExerciseService(ExerciseRepository())
+        exercise_repo = ExerciseRepository()
+        exercise_service = ExerciseService(exercise_repo)
         self.session_controller = SessionController(
             session_service, client_service, exercise_service
         )
@@ -80,7 +81,7 @@ class CoachApp(ctk.CTk):
         result_repo = ResultatExerciceRepository()
         tracking_service = TrackingService(result_repo)
         self.tracking_controller = TrackingController(
-            tracking_service, session_service, ExerciseRepository()
+            tracking_service, session_service, exercise_repo
         )
 
         calendar_service = CalendarService(sessions_repo)


### PR DESCRIPTION
## Summary
- instantiate `exercise_repo` once in `app.py`
- share repository with `ExerciseService` and `TrackingController` to avoid duplicate instances

## Testing
- `pre-commit run --files app.py`
- `pytest -q` *(fails: no display name and no $DISPLAY environment variable)*

------
https://chatgpt.com/codex/tasks/task_e_68b5bb684230832a8309b5aa5ca45605